### PR TITLE
hybris-patches: reach main init state by setting vold property.

### DIFF
--- a/system/core/0001-hybris-Add-usr-libexec-droid-hybris-lib-dev-alog-to-.patch
+++ b/system/core/0001-hybris-Add-usr-libexec-droid-hybris-lib-dev-alog-to-.patch
@@ -1,7 +1,7 @@
-From 1cf676b0394b4062c922510926201f88155ec0a6 Mon Sep 17 00:00:00 2001
+From 3f10a48c586a2e21b2967ffdb6233475eefef726 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 6 Nov 2013 21:09:30 +0000
-Subject: [PATCH 01/37] (hybris) Add /usr/libexec/droid-hybris/lib-dev-alog/ to
+Subject: [PATCH 01/39] (hybris) Add /usr/libexec/droid-hybris/lib-dev-alog/ to
  the LD_LIBRARY_PATH for all init'ed binaries to support the /dev/alog used in
  Mer
 
@@ -11,7 +11,7 @@ Change-Id: If58b8bd7c52b71e6e1f86f714142890dc8c73fd8
  1 file changed, 4 insertions(+)
 
 diff --git a/rootdir/init.environ.rc.in b/rootdir/init.environ.rc.in
-index 2e2ab74..deefac4 100644
+index 2e2ab7465..deefac4e0 100644
 --- a/rootdir/init.environ.rc.in
 +++ b/rootdir/init.environ.rc.in
 @@ -1,5 +1,9 @@
@@ -25,5 +25,5 @@ index 2e2ab74..deefac4 100644
      export ANDROID_ROOT /system
      export ANDROID_ASSETS /system/app
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0002-hybris-Don-t-create-mount-dev-proc-sys.-when-booting.patch
+++ b/system/core/0002-hybris-Don-t-create-mount-dev-proc-sys.-when-booting.patch
@@ -1,7 +1,7 @@
-From 55bc676d405124e4c41e1ad900c1480389918bc7 Mon Sep 17 00:00:00 2001
+From 1653fc62093ef821c1d949b14d6d9e6e303f0734 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 8 Oct 2013 16:59:30 +0100
-Subject: [PATCH 02/37] (hybris) Don't create/mount dev/proc/sys... when
+Subject: [PATCH 02/39] (hybris) Don't create/mount dev/proc/sys... when
  booting with Mer
 
 Change-Id: I16afd5bf56ee3e36f09b3496b80e356ce9269a64
@@ -10,10 +10,10 @@ Change-Id: I16afd5bf56ee3e36f09b3496b80e356ce9269a64
  1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index 4fe115e..93282fd 100644
+index fc58eeabb..527d275c7 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
-@@ -573,17 +573,17 @@ int main(int argc, char** argv) {
+@@ -574,17 +574,17 @@ int main(int argc, char** argv) {
          setenv("PATH", _PATH_DEFPATH, 1);
          // Get the basic filesystem setup we need put together in the initramdisk
          // on / and then we'll let the rc file figure out the rest.
@@ -37,5 +37,5 @@ index 4fe115e..93282fd 100644
  
          mknod("/dev/kmsg", S_IFCHR | 0600, makedev(1, 11));
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0003-hybris-Mer-can-specify-mis-alignment-handling-this-i.patch
+++ b/system/core/0003-hybris-Mer-can-specify-mis-alignment-handling-this-i.patch
@@ -1,7 +1,7 @@
-From ebb6134e85e174c4602cf9b6aa461d35b240ad2b Mon Sep 17 00:00:00 2001
+From 1fb89692cc9d2dbb4ae1e9b861efd7ca9f3141c9 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:07:56 +0100
-Subject: [PATCH 03/37] (hybris) Mer can specify mis-alignment handling - this
+Subject: [PATCH 03/39] (hybris) Mer can specify mis-alignment handling - this
  is the wrong place to set it
 
 Change-Id: Ib46c0a0b6d285dbcd05736e7ba9e9fd0a0480984
@@ -10,7 +10,7 @@ Change-Id: Ib46c0a0b6d285dbcd05736e7ba9e9fd0a0480984
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 13c5a07..0072393 100644
+index 13c5a07fd..007239393 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -109,13 +109,15 @@ on init
@@ -31,5 +31,5 @@ index 13c5a07..0072393 100644
      write /proc/sys/kernel/sched_wakeup_granularity_ns 2000000
      write /proc/sys/kernel/sched_child_runs_first 0
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0004-hybris-Mount-points-are-handled-by-Mer.patch
+++ b/system/core/0004-hybris-Mount-points-are-handled-by-Mer.patch
@@ -1,7 +1,7 @@
-From d777273150af1a7f6f23022590774484ed50822e Mon Sep 17 00:00:00 2001
+From c8da084003e5d6b3f22ab9811f3d1b5c3d9f6a59 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:09:20 +0100
-Subject: [PATCH 04/37] (hybris) Mount points are handled by Mer
+Subject: [PATCH 04/39] (hybris) Mount points are handled by Mer
 
 Change-Id: I295b30a47b6e147b037275032a00b304085fe711
 ---
@@ -9,7 +9,7 @@ Change-Id: I295b30a47b6e147b037275032a00b304085fe711
  1 file changed, 8 insertions(+), 6 deletions(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 0072393..513d32e 100644
+index 007239393..513d32e24 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -45,8 +45,10 @@ on init
@@ -43,5 +43,5 @@ index 0072393..513d32e 100644
      # Make sure /sys/kernel/debug (if present) is labeled properly
      # Note that tracefs may be mounted under debug, so we need to cross filesystems
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0005-hybris-Systemd-handles-control-groups.patch
+++ b/system/core/0005-hybris-Systemd-handles-control-groups.patch
@@ -1,7 +1,7 @@
-From ba135c5da262aa6e07252f054d954ac8506d9618 Mon Sep 17 00:00:00 2001
+From 0e7d0f8148750dc788a62f85496d32f2b384594d Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:10:16 +0100
-Subject: [PATCH 05/37] (hybris) Systemd handles control groups
+Subject: [PATCH 05/39] (hybris) Systemd handles control groups
 
 Change-Id: I92ef4b2389544906be32169c57176575eb1719ec
 ---
@@ -9,7 +9,7 @@ Change-Id: I92ef4b2389544906be32169c57176575eb1719ec
  1 file changed, 8 deletions(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 513d32e..c882e4c 100644
+index 513d32e24..c882e4c3a 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -28,14 +28,6 @@ on early-init
@@ -28,5 +28,5 @@ index 513d32e..c882e4c 100644
  
  on init
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0006-hybris-Mer-uses-udev.patch
+++ b/system/core/0006-hybris-Mer-uses-udev.patch
@@ -1,7 +1,7 @@
-From 4145a522c6aaede35a0c64bf6e346c5d43ac897a Mon Sep 17 00:00:00 2001
+From 61feac7fde3426622401f5454413245217049e4c Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:12:18 +0100
-Subject: [PATCH 06/37] (hybris) Mer uses udev
+Subject: [PATCH 06/39] (hybris) Mer uses udev
 
 Change-Id: I7588a80db2c77879fb56d5decfd055224f20ab54
 ---
@@ -9,7 +9,7 @@ Change-Id: I7588a80db2c77879fb56d5decfd055224f20ab54
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index c882e4c..2c45bb7 100644
+index c882e4c3a..2c45bb7e7 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -28,7 +28,7 @@ on early-init
@@ -22,5 +22,5 @@ index c882e4c..2c45bb7 100644
  on init
      sysclktz 0
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0007-hybris-Add-a-ready-trigger-to-init-to-run-post-boot.patch
+++ b/system/core/0007-hybris-Add-a-ready-trigger-to-init-to-run-post-boot.patch
@@ -1,7 +1,7 @@
-From 34e2349f3ac919f6867dff7b4c4d373d8f2474e1 Mon Sep 17 00:00:00 2001
+From 6586a8c81cfc326f1cc7e3bbed8e1bc3a5247806 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 20 Nov 2013 19:18:51 +0000
-Subject: [PATCH 07/37] (hybris) Add a ready trigger to init to run post boot
+Subject: [PATCH 07/39] (hybris) Add a ready trigger to init to run post boot
 
 Change-Id: I9c828463424c0e82c3de0159db08299e7ce6fe06
 ---
@@ -9,10 +9,10 @@ Change-Id: I9c828463424c0e82c3de0159db08299e7ce6fe06
  1 file changed, 6 insertions(+)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index 93282fd..f492d4d 100644
+index 527d275c7..9a451877a 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
-@@ -746,6 +746,12 @@ int main(int argc, char** argv) {
+@@ -750,6 +750,12 @@ int main(int argc, char** argv) {
      // Run all property triggers based on current state of the properties.
      am.QueueBuiltinAction(queue_property_triggers_action, "queue_property_triggers");
  
@@ -26,5 +26,5 @@ index 93282fd..f492d4d 100644
          // By default, sleep until something happens.
          int epoll_timeout_ms = -1;
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0008-hybris-Notify-Mer-s-systemd-that-we-re-done.patch
+++ b/system/core/0008-hybris-Notify-Mer-s-systemd-that-we-re-done.patch
@@ -1,7 +1,7 @@
-From f510929d2095cc856213cae18bc979eeee707a60 Mon Sep 17 00:00:00 2001
+From e59568278cf4a68586c426bdd2e5e5463255fce4 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 20 Nov 2013 19:24:31 +0000
-Subject: [PATCH 08/37] (hybris) Notify Mer's systemd that we're done
+Subject: [PATCH 08/39] (hybris) Notify Mer's systemd that we're done
 
 Change-Id: If6a16f43397f00c8e579af79ae6cf8459786e7b3
 Signed-off-by: David Greaves <david.greaves@jollamobile.com>
@@ -10,7 +10,7 @@ Signed-off-by: David Greaves <david.greaves@jollamobile.com>
  1 file changed, 16 insertions(+)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 2c45bb7..fbab513 100644
+index 2c45bb7e7..fbab513e5 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -763,3 +763,19 @@ on property:ro.debuggable=1
@@ -34,5 +34,5 @@ index 2c45bb7..fbab513 100644
 +    start flash_recovery
 +
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0009-hybris-Disable-usb-import.patch
+++ b/system/core/0009-hybris-Disable-usb-import.patch
@@ -1,7 +1,7 @@
-From 063884fbe11097fb83f334e107c698d3a065bbc8 Mon Sep 17 00:00:00 2001
+From ac150f4c0fe71d9535c4e79a3b5de0563ba1f1c6 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 19 Feb 2014 19:02:32 +0000
-Subject: [PATCH 09/37] (hybris) Disable usb import
+Subject: [PATCH 09/39] (hybris) Disable usb import
 
 Change-Id: I8aba60bc79fb4aab3854f0569b325ad69c5126d4
 Signed-off-by: David Greaves <david@dgreaves.com>
@@ -10,7 +10,7 @@ Signed-off-by: David Greaves <david@dgreaves.com>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index fbab513..2049b60 100644
+index fbab513e5..2049b6029 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -5,7 +5,8 @@
@@ -24,5 +24,5 @@ index fbab513..2049b60 100644
  import /vendor/etc/init/hw/init.${ro.hardware}.rc
  import /init.usb.configfs.rc
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0010-hybris-allow-system-group-to-trigger-haptics.patch
+++ b/system/core/0010-hybris-allow-system-group-to-trigger-haptics.patch
@@ -1,7 +1,7 @@
-From 64a585da8d93159bbb1ea3cd64a65bb39580f28f Mon Sep 17 00:00:00 2001
+From db649dd9c1c1a4608a9d6c3daefbdd168795effc Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Thu, 13 Mar 2014 08:51:53 +0000
-Subject: [PATCH 10/37] (hybris) allow system group to trigger haptics
+Subject: [PATCH 10/39] (hybris) allow system group to trigger haptics
 
 Signed-off-by: Simonas Leleiva <simonas.leleiva@jollamobile.com>
 
@@ -14,7 +14,7 @@ Change-Id: I9f1af094fa8a4ef48f4c3ea0ec35cb66d3c083d8
  1 file changed, 3 insertions(+)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 2049b60..bed210a 100644
+index 2049b6029..bed210a7d 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -669,6 +669,9 @@ on boot
@@ -28,5 +28,5 @@ index 2049b60..bed210a 100644
      class_start hal
  
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0011-hybris-trigger-late_start-on-property-change.patch
+++ b/system/core/0011-hybris-trigger-late_start-on-property-change.patch
@@ -1,7 +1,7 @@
-From cf00c01d09a8a3a8712ce32527a59e84fc58fadb Mon Sep 17 00:00:00 2001
+From df2bf62529358098e1bf7402094c302765a8155c Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Tue, 18 Mar 2014 14:07:11 +0000
-Subject: [PATCH 11/37] (hybris) trigger late_start on property change
+Subject: [PATCH 11/39] (hybris) trigger late_start on property change
 
 Android's late_start is triggered by mount_all, which also determines whether
 the /data partition is encrypted.
@@ -20,7 +20,7 @@ Conflicts:
  1 file changed, 5 insertions(+)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index bed210a..34d46f6 100644
+index bed210a7d..34d46f6d2 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -677,6 +677,7 @@ on boot
@@ -43,5 +43,5 @@ index bed210a..34d46f6 100644
      class_start charger
  
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0012-hybris-property_service.c-adding-support-for-getprop.patch
+++ b/system/core/0012-hybris-property_service.c-adding-support-for-getprop.patch
@@ -1,7 +1,7 @@
-From dc6405f9886a3587941dcc7dc0f1494acfab5535 Mon Sep 17 00:00:00 2001
+From 6cf9230f3f32233b6ad101f244a1ed4b914c1355 Mon Sep 17 00:00:00 2001
 From: Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
 Date: Thu, 31 Oct 2013 12:19:19 +0200
-Subject: [PATCH 12/37] (hybris) property_service.c: adding support for getprop
+Subject: [PATCH 12/39] (hybris) property_service.c: adding support for getprop
  and listprop
 
 Change-Id: Ie5fbdb55c48038ce8250f27500623b3b81cc5cd1
@@ -19,10 +19,10 @@ Conflicts:
  2 files changed, 38 insertions(+), 1 deletion(-)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index f492d4d..5fb32cb 100644
+index 9a451877a..49f646797 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
-@@ -698,6 +698,7 @@ int main(int argc, char** argv) {
+@@ -699,6 +699,7 @@ int main(int argc, char** argv) {
          InstallSigtermHandler();
      }
  
@@ -30,7 +30,7 @@ index f492d4d..5fb32cb 100644
      property_load_boot_defaults();
      export_oem_lock_status();
      start_property_service();
-@@ -747,7 +748,7 @@ int main(int argc, char** argv) {
+@@ -751,7 +752,7 @@ int main(int argc, char** argv) {
      am.QueueBuiltinAction(queue_property_triggers_action, "queue_property_triggers");
  
      /* run all device triggers based on current state of device nodes in /dev */
@@ -40,7 +40,7 @@ index f492d4d..5fb32cb 100644
      /* Run actions when all boot up is done and init is ready */
      am.QueueEventTrigger("ready");
 diff --git a/init/property_service.cpp b/init/property_service.cpp
-index 4172ba7..f097531 100644
+index 4172ba754..f0975313b 100644
 --- a/init/property_service.cpp
 +++ b/init/property_service.cpp
 @@ -481,6 +481,9 @@ uint32_t HandlePropertySet(const std::string& name, const std::string& value,
@@ -95,5 +95,5 @@ index 4172ba7..f097531 100644
          LOG(ERROR) << "sys_prop: invalid command " << cmd;
          socket.SendUint32(PROP_ERROR_INVALID_CMD);
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0013-hybris-reach-main-init-state.patch
+++ b/system/core/0013-hybris-reach-main-init-state.patch
@@ -1,25 +1,28 @@
-From 56f513813205ddb1b3c6861c77ad6cb41bd84c9c Mon Sep 17 00:00:00 2001
+From 31251fc4ee21ac0248be27efeb933dbd415e7cba Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Sat, 22 Aug 2015 12:03:42 +0100
-Subject: [PATCH 13/37] (hybris) reach main init state
+Subject: [PATCH 13/39] (hybris) reach main init state
 
 Change-Id: I471f48afaebf91c92f0d2a7bd3a24c5d1fa58ecd
 ---
- rootdir/init.rc | 1 +
- 1 file changed, 1 insertion(+)
+ rootdir/init.rc | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 34d46f6..27d2b01 100644
+index 34d46f6d2..cfebb021e 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
-@@ -676,6 +676,7 @@ on boot
-     class_start hal
+@@ -386,7 +386,9 @@ on post-fs-data
+     restorecon /data
  
-     class_start core
-+    class_start main
+     # Make sure we have the device encryption key.
+-    start vold
++    #start vold
++    # hybris continue bootup properly
++    setprop vold.decrypt trigger_restart_min_framework
+     installkey /data
  
- # Never gets called, since Mer does its own 'mount_all'
- on nonencrypted
+     # Start bootcharting as soon as possible after the data partition is
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0014-hybris-Disable-setting-hostname-and-domainname-in-in.patch
+++ b/system/core/0014-hybris-Disable-setting-hostname-and-domainname-in-in.patch
@@ -1,7 +1,7 @@
-From 8c7668bdc2aad52d954842d64413e868afa53c87 Mon Sep 17 00:00:00 2001
+From e24b889037c7d50de1a0bde386fc7023fa8607c0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Sat, 6 Aug 2016 11:37:38 +0300
-Subject: [PATCH 14/37] (hybris) Disable setting hostname and domainname in
+Subject: [PATCH 14/39] (hybris) Disable setting hostname and domainname in
  init.rc.
 
 Change-Id: I5b9f59e80760e53636763c89f8f76f350c17b3ec
@@ -10,10 +10,10 @@ Change-Id: I5b9f59e80760e53636763c89f8f76f350c17b3ec
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 27d2b01..318b935 100644
+index cfebb021e..876955018 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
-@@ -578,8 +578,9 @@ on zygote-start && property:ro.crypto.state=encrypted && property:ro.crypto.type
+@@ -580,8 +580,9 @@ on zygote-start && property:ro.crypto.state=encrypted && property:ro.crypto.type
  on boot
      # basic network init
      ifup lo
@@ -26,5 +26,5 @@ index 27d2b01..318b935 100644
      # IPsec SA default expiration length
      write /proc/sys/net/core/xfrm_acq_expires 3600
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0015-hybris-Update-rootdir-for-64bit-libs.patch
+++ b/system/core/0015-hybris-Update-rootdir-for-64bit-libs.patch
@@ -1,7 +1,7 @@
-From a3ca802f6c92e7fbe40f1b3f30a6cec9eeb8b934 Mon Sep 17 00:00:00 2001
+From f407437fd7b447f4b8f5262299c16fe0e33514e4 Mon Sep 17 00:00:00 2001
 From: Martin Ghosal <Martin.Ghosal@sky.uk>
 Date: Sat, 15 Oct 2016 15:38:47 +0100
-Subject: [PATCH 15/37] (hybris) Update rootdir for 64bit libs
+Subject: [PATCH 15/39] (hybris) Update rootdir for 64bit libs
 
 Change-Id: I593ae40da755c116bb28c96dcace863e6b30b4cc
 ---
@@ -9,7 +9,7 @@ Change-Id: I593ae40da755c116bb28c96dcace863e6b30b4cc
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.environ.rc.in b/rootdir/init.environ.rc.in
-index deefac4..144f3d3 100644
+index deefac4e0..144f3d396 100644
 --- a/rootdir/init.environ.rc.in
 +++ b/rootdir/init.environ.rc.in
 @@ -3,7 +3,8 @@ on init
@@ -23,5 +23,5 @@ index deefac4..144f3d3 100644
      export ANDROID_ROOT /system
      export ANDROID_ASSETS /system/app
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0016-hybris-Disable-all-zygote-variations.patch
+++ b/system/core/0016-hybris-Disable-all-zygote-variations.patch
@@ -1,7 +1,7 @@
-From 0158a3dc1d4826f0ba6f170d5a04852f73f64825 Mon Sep 17 00:00:00 2001
+From a2fbf62f4b43e628a1146a1714ba64c233b8a60d Mon Sep 17 00:00:00 2001
 From: Martin Ghosal <Martin.Ghosal@sky.uk>
 Date: Sun, 8 Jan 2017 16:34:54 +0000
-Subject: [PATCH 16/37] (hybris) Disable all zygote variations
+Subject: [PATCH 16/39] (hybris) Disable all zygote variations
 
 Change-Id: Ie1ad26486f47b3bf67134db917b3c9e51536904c
 ---
@@ -12,7 +12,7 @@ Change-Id: Ie1ad26486f47b3bf67134db917b3c9e51536904c
  4 files changed, 6 insertions(+)
 
 diff --git a/rootdir/init.zygote32.rc b/rootdir/init.zygote32.rc
-index ac87979..b24f7b5 100644
+index ac87979ec..b24f7b5b9 100644
 --- a/rootdir/init.zygote32.rc
 +++ b/rootdir/init.zygote32.rc
 @@ -12,3 +12,4 @@ service zygote /system/bin/app_process -Xzygote /system/bin --zygote --start-sys
@@ -21,7 +21,7 @@ index ac87979..b24f7b5 100644
      writepid /dev/cpuset/foreground/tasks
 +    disabled
 diff --git a/rootdir/init.zygote32_64.rc b/rootdir/init.zygote32_64.rc
-index a535846..62b9236 100644
+index a535846de..62b92363c 100644
 --- a/rootdir/init.zygote32_64.rc
 +++ b/rootdir/init.zygote32_64.rc
 @@ -12,6 +12,7 @@ service zygote /system/bin/app_process32 -Xzygote /system/bin --zygote --start-s
@@ -38,7 +38,7 @@ index a535846..62b9236 100644
      writepid /dev/cpuset/foreground/tasks
 +    disabled
 diff --git a/rootdir/init.zygote64.rc b/rootdir/init.zygote64.rc
-index 6fc810b..edf82ce 100644
+index 6fc810bfa..edf82ce4b 100644
 --- a/rootdir/init.zygote64.rc
 +++ b/rootdir/init.zygote64.rc
 @@ -12,3 +12,4 @@ service zygote /system/bin/app_process64 -Xzygote /system/bin --zygote --start-s
@@ -47,7 +47,7 @@ index 6fc810b..edf82ce 100644
      writepid /dev/cpuset/foreground/tasks
 +    disabled
 diff --git a/rootdir/init.zygote64_32.rc b/rootdir/init.zygote64_32.rc
-index 7ddd52e..e74202a 100644
+index 7ddd52ee5..e74202a7e 100644
 --- a/rootdir/init.zygote64_32.rc
 +++ b/rootdir/init.zygote64_32.rc
 @@ -12,6 +12,7 @@ service zygote /system/bin/app_process64 -Xzygote /system/bin --zygote --start-s
@@ -64,5 +64,5 @@ index 7ddd52e..e74202a 100644
      writepid /dev/cpuset/foreground/tasks
 +    disabled
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0017-hybris-Disable-ueventd-service.patch
+++ b/system/core/0017-hybris-Disable-ueventd-service.patch
@@ -1,7 +1,7 @@
-From 50d6d27f2bd097883d4188d12b4145273b14c8ea Mon Sep 17 00:00:00 2001
+From c4ad75533aa1bf52cf88d0c7245236a05d229d77 Mon Sep 17 00:00:00 2001
 From: Martin Ghosal <Martin.Ghosal@sky.uk>
 Date: Sun, 8 Jan 2017 17:16:08 +0000
-Subject: [PATCH 17/37] (hybris) Disable ueventd service
+Subject: [PATCH 17/39] (hybris) Disable ueventd service
 
 Change-Id: I8ee7b863a533f4a6ef7658ef1c1ef4bdb95d5d65
 ---
@@ -9,10 +9,10 @@ Change-Id: I8ee7b863a533f4a6ef7658ef1c1ef4bdb95d5d65
  1 file changed, 2 insertions(+)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 318b935..9cca537 100644
+index 876955018..3176fe17b 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
-@@ -753,6 +753,8 @@ service ueventd /sbin/ueventd
+@@ -754,6 +754,8 @@ service ueventd /sbin/ueventd
      critical
      seclabel u:r:ueventd:s0
      shutdown critical
@@ -22,5 +22,5 @@ index 318b935..9cca537 100644
  service console /system/bin/sh
      class core
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0018-hybris-Disable-SELinux.patch
+++ b/system/core/0018-hybris-Disable-SELinux.patch
@@ -1,7 +1,7 @@
-From dd5df0e010f620c5bdcdf5455b794fdf43fd0612 Mon Sep 17 00:00:00 2001
+From 2073c43d7f5cff33f20dc1437f68e78b37ae2c6f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Thu, 9 Feb 2017 21:48:19 +0200
-Subject: [PATCH 18/37] (hybris) Disable SELinux
+Subject: [PATCH 18/39] (hybris) Disable SELinux
 
 Change-Id: I0511b2a0de1b20996f4fb8e9f3569acb41e2cf0f
 ---
@@ -11,7 +11,7 @@ Change-Id: I0511b2a0de1b20996f4fb8e9f3569acb41e2cf0f
  3 files changed, 14 insertions(+), 1 deletion(-)
 
 diff --git a/init/property_service.cpp b/init/property_service.cpp
-index f097531..3333eed 100644
+index f0975313b..3333eedb1 100644
 --- a/init/property_service.cpp
 +++ b/init/property_service.cpp
 @@ -112,6 +112,8 @@ void property_init() {
@@ -24,7 +24,7 @@ index f097531..3333eed 100644
          return false;
      }
 diff --git a/init/selinux.cpp b/init/selinux.cpp
-index 0ba5c4a..416c127 100644
+index 0ba5c4ae3..416c12789 100644
 --- a/init/selinux.cpp
 +++ b/init/selinux.cpp
 @@ -382,6 +382,9 @@ bool LoadPolicy() {
@@ -38,7 +38,7 @@ index 0ba5c4a..416c127 100644
  
      LOG(INFO) << "Loading SELinux policy";
 diff --git a/init/service.cpp b/init/service.cpp
-index 37d3a88..9c294af 100644
+index 37d3a8807..9c294af15 100644
 --- a/init/service.cpp
 +++ b/init/service.cpp
 @@ -66,6 +66,8 @@ using android::base::WriteStringToFile;
@@ -92,5 +92,5 @@ index 37d3a88..9c294af 100644
  
      pid_t pid = -1;
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0019-hybris-Properly-handle-shutdown-from-Mer.patch
+++ b/system/core/0019-hybris-Properly-handle-shutdown-from-Mer.patch
@@ -1,18 +1,18 @@
-From 99594259702150fd09438e68f0aa59617fd7f8fb Mon Sep 17 00:00:00 2001
+From 35bbe378ee929986fb580324be7c8cc8f8cd76e9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Sat, 8 Jul 2017 00:27:20 +0300
-Subject: [PATCH 19/37] (hybris) Properly handle shutdown from Mer.
+Subject: [PATCH 19/39] (hybris) Properly handle shutdown from Mer.
 
 Change-Id: I89daebb9559d38f3c639f4634c417252c7a92fe0
 ---
- rootdir/init.rc | 6 ++++++
- 1 file changed, 6 insertions(+)
+ rootdir/init.rc | 9 +++++++++
+ 1 file changed, 9 insertions(+)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 9cca537..16d68d3 100644
+index 3176fe17b..86f657be2 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
-@@ -788,6 +788,12 @@ service droid_init_done /bin/sh /usr/bin/droid/droid-init-done.sh
+@@ -789,6 +789,15 @@ service droid_init_done /bin/sh /usr/bin/droid/droid-init-done.sh
      class mer
      oneshot
  
@@ -20,11 +20,14 @@ index 9cca537..16d68d3 100644
 +on property:hybris.shutdown=*
 +    class_stop late_start
 +    class_stop main
++    class_stop charger
++    class_stop hal
++    class_stop early_hal
 +    class_stop core
 +
  # update recovery if enabled
  on property:persist.sys.recovery_update=true
      start flash_recovery
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0020-hybris-Use-services-from-usr-libexec-droid-hybris-sy.patch
+++ b/system/core/0020-hybris-Use-services-from-usr-libexec-droid-hybris-sy.patch
@@ -1,22 +1,22 @@
-From cff254ce062c1e8420e4e3680097ac55896e6290 Mon Sep 17 00:00:00 2001
+From 56e074cab0466e0f6f00f983f870d39c892f205e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Thu, 9 Feb 2017 21:57:47 +0200
-Subject: [PATCH 20/37] (hybris) Use services from
+Subject: [PATCH 20/39] (hybris) Use services from
  /usr/libexec/droid-hybris/system/etc/init/.
 
 Change-Id: I6185781c2bd6a2db281201ad705394f4d6d24131
 ---
  init/init.cpp        |   4 +-
- init/init_parser.cpp | 169 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ init/init_parser.cpp | 169 +++++++++++++++++++++++++++++++++++++++++++
  init/util.cpp        |   3 +-
  3 files changed, 173 insertions(+), 3 deletions(-)
  create mode 100644 init/init_parser.cpp
 
 diff --git a/init/init.cpp b/init/init.cpp
-index 5fb32cb..c631fc2 100644
+index 49f646797..8dc013d3e 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
-@@ -113,8 +113,8 @@ static void LoadBootScripts(ActionManager& action_manager, ServiceList& service_
+@@ -114,8 +114,8 @@ static void LoadBootScripts(ActionManager& action_manager, ServiceList& service_
      std::string bootscript = GetProperty("ro.boot.init_rc", "");
      if (bootscript.empty()) {
          parser.ParseConfig("/init.rc");
@@ -29,7 +29,7 @@ index 5fb32cb..c631fc2 100644
              late_import_paths.emplace_back("/product/etc/init");
 diff --git a/init/init_parser.cpp b/init/init_parser.cpp
 new file mode 100644
-index 0000000..c4b8063
+index 000000000..c4b80636a
 --- /dev/null
 +++ b/init/init_parser.cpp
 @@ -0,0 +1,169 @@
@@ -203,7 +203,7 @@ index 0000000..c4b8063
 +}  // namespace init
 +}  // namespace android
 diff --git a/init/util.cpp b/init/util.cpp
-index 4455b2e..8eb184d 100644
+index 4455b2eb1..8eb184da9 100644
 --- a/init/util.cpp
 +++ b/init/util.cpp
 @@ -162,7 +162,8 @@ out_unlink:
@@ -217,5 +217,5 @@ index 4455b2e..8eb184d 100644
          return ErrnoError() << "open() failed";
      }
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0021-hybris-Remove-LD_LIBRARY_PATH-from-init.environ.rc.patch
+++ b/system/core/0021-hybris-Remove-LD_LIBRARY_PATH-from-init.environ.rc.patch
@@ -1,7 +1,7 @@
-From b0b0e5ab86a9d9bc736abd90dcbbaef4ef22c98d Mon Sep 17 00:00:00 2001
+From 91eab95aa6c08d1d6b0a34396f3fdc82c94ad06e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Tue, 17 Oct 2017 21:58:40 +0300
-Subject: [PATCH 21/37] (hybris) Remove LD_LIBRARY_PATH from init.environ.rc
+Subject: [PATCH 21/39] (hybris) Remove LD_LIBRARY_PATH from init.environ.rc
 
 Change-Id: I52a2c733f609f90b6ac31be72a4f8fe7681beac0
 ---
@@ -9,7 +9,7 @@ Change-Id: I52a2c733f609f90b6ac31be72a4f8fe7681beac0
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.environ.rc.in b/rootdir/init.environ.rc.in
-index 144f3d3..fcafbb1 100644
+index 144f3d396..fcafbb113 100644
 --- a/rootdir/init.environ.rc.in
 +++ b/rootdir/init.environ.rc.in
 @@ -4,7 +4,8 @@ on init
@@ -23,5 +23,5 @@ index 144f3d3..fcafbb1 100644
      export ANDROID_ROOT /system
      export ANDROID_ASSETS /system/app
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0022-hybris-define-32-bit-LD_LIBRARY_PATH-for-32-bit-devi.patch
+++ b/system/core/0022-hybris-define-32-bit-LD_LIBRARY_PATH-for-32-bit-devi.patch
@@ -1,7 +1,7 @@
-From 09d7863a41e41d783af43f402168d5ec97c6a96b Mon Sep 17 00:00:00 2001
+From 8f109bc7e60a69df91ba0fd6d98b056e8f108f71 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jollamobile.com>
 Date: Wed, 25 Oct 2017 14:14:59 +0300
-Subject: [PATCH 22/37] (hybris) define 32-bit LD_LIBRARY_PATH for 32-bit
+Subject: [PATCH 22/39] (hybris) define 32-bit LD_LIBRARY_PATH for 32-bit
  devices
 
 ---
@@ -13,7 +13,7 @@ Subject: [PATCH 22/37] (hybris) define 32-bit LD_LIBRARY_PATH for 32-bit
  create mode 100644 rootdir/init.extraenv.armeabi-v7a.rc
 
 diff --git a/rootdir/Android.mk b/rootdir/Android.mk
-index 5f5c363..af5e68d 100644
+index 5f5c363a7..af5e68d3a 100644
 --- a/rootdir/Android.mk
 +++ b/rootdir/Android.mk
 @@ -8,6 +8,18 @@ LOCAL_MODULE := init.rc
@@ -36,7 +36,7 @@ index 5f5c363..af5e68d 100644
  include $(BUILD_PREBUILT)
  
 diff --git a/rootdir/init.environ.rc.in b/rootdir/init.environ.rc.in
-index fcafbb1..516dc82 100644
+index fcafbb113..516dc82f6 100644
 --- a/rootdir/init.environ.rc.in
 +++ b/rootdir/init.environ.rc.in
 @@ -5,6 +5,7 @@ on init
@@ -49,14 +49,14 @@ index fcafbb1..516dc82 100644
      export ANDROID_ROOT /system
 diff --git a/rootdir/init.extraenv.armeabi-v7a.rc b/rootdir/init.extraenv.armeabi-v7a.rc
 new file mode 100644
-index 0000000..c96e2c6
+index 000000000..c96e2c65d
 --- /dev/null
 +++ b/rootdir/init.extraenv.armeabi-v7a.rc
 @@ -0,0 +1,2 @@
 +on init
 +    export LD_LIBRARY_PATH /usr/libexec/droid-hybris/lib-dev-alog:/vendor/lib:/system/lib
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 16d68d3..85323a1 100644
+index 86f657be2..8afcfcc67 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -4,6 +4,11 @@
@@ -72,5 +72,5 @@ index 16d68d3..85323a1 100644
  # Mer handles usb stuff
  #import /init.usb.rc
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0023-hybris-Fix-list-and-get-properties.patch
+++ b/system/core/0023-hybris-Fix-list-and-get-properties.patch
@@ -1,7 +1,7 @@
-From 7397230653c24b878734560b51e5ad6481427d9c Mon Sep 17 00:00:00 2001
+From 77ffc7ac438edf9827be45b1f4db0b732d2d3779 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Tue, 16 Jan 2018 16:18:31 +0200
-Subject: [PATCH 23/37] (hybris) Fix list and get properties.
+Subject: [PATCH 23/39] (hybris) Fix list and get properties.
 
 Change-Id: I9deb65f147e941fc5c9f91793f851440d02260e1
 ---
@@ -9,7 +9,7 @@ Change-Id: I9deb65f147e941fc5c9f91793f851440d02260e1
  1 file changed, 30 insertions(+), 5 deletions(-)
 
 diff --git a/init/property_service.cpp b/init/property_service.cpp
-index 3333eed..5bead05 100644
+index 3333eedb1..5bead058c 100644
 --- a/init/property_service.cpp
 +++ b/init/property_service.cpp
 @@ -269,6 +269,13 @@ uint32_t InitPropertySet(const std::string& name, const std::string& value) {
@@ -88,5 +88,5 @@ index 3333eed..5bead05 100644
          break;
        }
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0024-hybris-more-SELinux-disablement.patch
+++ b/system/core/0024-hybris-more-SELinux-disablement.patch
@@ -1,7 +1,7 @@
-From e1a58aa7564bfde917461a137007014aa39d9c54 Mon Sep 17 00:00:00 2001
+From 1ce5df555b3ba8f7995e1907d3616e7491d704a8 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Wed, 18 Apr 2018 18:49:02 +0200
-Subject: [PATCH 24/37] (hybris) more SELinux disablement
+Subject: [PATCH 24/39] (hybris) more SELinux disablement
 
 Change-Id: Ic1bc474e993f2b66ab9114e88d7ec4f718a99d5c
 Signed-off-by: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
@@ -11,10 +11,10 @@ Signed-off-by: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
  2 files changed, 6 insertions(+)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index c631fc2..cdab577 100644
+index 8dc013d3e..e397c4c58 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
-@@ -668,7 +668,10 @@ int main(int argc, char** argv) {
+@@ -669,7 +669,10 @@ int main(int argc, char** argv) {
  
      // Make the time that init started available for bootstat to log.
      property_set("ro.boottime.init", getenv("INIT_STARTED_AT"));
@@ -26,7 +26,7 @@ index c631fc2..cdab577 100644
      // Set libavb version for Framework-only OTA match in Treble build.
      const char* avb_version = getenv("INIT_AVB_VERSION");
 diff --git a/init/log.cpp b/init/log.cpp
-index 6198fc2..0c7c7b5 100644
+index 6198fc25f..0c7c7b50d 100644
 --- a/init/log.cpp
 +++ b/init/log.cpp
 @@ -54,6 +54,8 @@ static void InitAborter(const char* abort_message) {
@@ -47,5 +47,5 @@ index 6198fc2..0c7c7b5 100644
      android::base::InitLogging(argv, &android::base::KernelLogger, InitAborter);
  }
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0025-hybris-don-t-try-to-mount-since-mer-handles-this.patch
+++ b/system/core/0025-hybris-don-t-try-to-mount-since-mer-handles-this.patch
@@ -1,7 +1,7 @@
-From 61b4530eed861401abdd2481d500744df50b4e9c Mon Sep 17 00:00:00 2001
+From 2b24443b29ef5118a4f919f6d4f9dee4aeaebfa7 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 4 Jun 2018 10:00:13 +0200
-Subject: [PATCH 25/37] (hybris) don't try to mount since mer handles this
+Subject: [PATCH 25/39] (hybris) don't try to mount since mer handles this
 
 Change-Id: I305ac649fd199ef11a8d88d350f1fc06171bc0ba
 ---
@@ -9,7 +9,7 @@ Change-Id: I305ac649fd199ef11a8d88d350f1fc06171bc0ba
  1 file changed, 3 insertions(+)
 
 diff --git a/init/init_first_stage.cpp b/init/init_first_stage.cpp
-index 033ce41..5c9aa93 100644
+index 033ce419a..5c9aa9306 100644
 --- a/init/init_first_stage.cpp
 +++ b/init/init_first_stage.cpp
 @@ -477,6 +477,7 @@ bool FirstStageMountVBootV2::InitAvbHandle() {
@@ -30,5 +30,5 @@ index 033ce41..5c9aa93 100644
  
  void SetInitAvbVersionInRecovery() {
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0026-hybris-avoid-attempting-to-mount-partitions-mer-syst.patch
+++ b/system/core/0026-hybris-avoid-attempting-to-mount-partitions-mer-syst.patch
@@ -1,7 +1,7 @@
-From 9d2d84e17d0e8777cbe5cf30f3a800d50b080486 Mon Sep 17 00:00:00 2001
+From 2e777b55382b5d5f4fdac35c6a0cac10c706f98c Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:28:27 +0200
-Subject: [PATCH 26/37] (hybris) avoid attempting to mount partitions,
+Subject: [PATCH 26/39] (hybris) avoid attempting to mount partitions,
  mer/systemd handles this
 
 Even partitions weren't mounted by this previously it still would produce an
@@ -13,7 +13,7 @@ Change-Id: Icaea2cd8d145d8205f4a130119aedbd2720c868d
  1 file changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/init/builtins.cpp b/init/builtins.cpp
-index 8bd92cc..8bb7b0f 100644
+index 8bd92ccdd..8bb7b0f0c 100644
 --- a/init/builtins.cpp
 +++ b/init/builtins.cpp
 @@ -416,6 +416,7 @@ static void import_late(const std::vector<std::string>& args, size_t start_index
@@ -66,5 +66,5 @@ index 8bd92cc..8bb7b0f 100644
          /* queue_fs_event will queue event based on mount_fstab return code
           * and return processed return code*/
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0027-hybris-load-services-from-droid-hybris-as-early-as-p.patch
+++ b/system/core/0027-hybris-load-services-from-droid-hybris-as-early-as-p.patch
@@ -1,7 +1,7 @@
-From cf969d037114abd2519f77bf2a4e7e13c32fe7c2 Mon Sep 17 00:00:00 2001
+From 6e89d8c8a8583630ad8743c043686c84ec936f27 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:30:01 +0200
-Subject: [PATCH 27/37] (hybris) load services from droid-hybris as early as
+Subject: [PATCH 27/39] (hybris) load services from droid-hybris as early as
  possible
 
 This makes sure our service definitions are loaded first and can be used to
@@ -14,10 +14,10 @@ Change-Id: I58e86f8b3c65f46c24fc3102a859867bccb6a713
  1 file changed, 3 insertions(+)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index cdab577..1ffa036 100644
+index e397c4c58..214c62215 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
-@@ -116,6 +116,9 @@ static void LoadBootScripts(ActionManager& action_manager, ServiceList& service_
+@@ -117,6 +117,9 @@ static void LoadBootScripts(ActionManager& action_manager, ServiceList& service_
          if (!parser.ParseConfig("/usr/libexec/droid-hybris/system/etc/init")) {
              late_import_paths.emplace_back("/usr/libexec/droid-hybris/system/etc/init");
          }
@@ -28,5 +28,5 @@ index cdab577..1ffa036 100644
              late_import_paths.emplace_back("/product/etc/init");
          }
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0028-hybris-disable-remnants-of-SELinux-which-currently-b.patch
+++ b/system/core/0028-hybris-disable-remnants-of-SELinux-which-currently-b.patch
@@ -1,7 +1,7 @@
-From 5d0e4ecbac99a9e4e8b9f262950033496b786886 Mon Sep 17 00:00:00 2001
+From 6fec76342654b725c766601228326d06ea0186ee Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:32:06 +0200
-Subject: [PATCH 28/37] (hybris) disable remnants of SELinux which currently
+Subject: [PATCH 28/39] (hybris) disable remnants of SELinux which currently
  break
 
 Change-Id: I252a8399c9853d993fc17d769bfbb2e4c722cfe8
@@ -10,7 +10,7 @@ Change-Id: I252a8399c9853d993fc17d769bfbb2e4c722cfe8
  1 file changed, 4 insertions(+)
 
 diff --git a/init/util.cpp b/init/util.cpp
-index 8eb184d..e27f4f8 100644
+index 8eb184da9..e27f4f88e 100644
 --- a/init/util.cpp
 +++ b/init/util.cpp
 @@ -87,12 +87,14 @@ Result<uid_t> DecodeUid(const std::string& name) {
@@ -39,5 +39,5 @@ index 8eb184d..e27f4f8 100644
      struct sockaddr_un addr;
      memset(&addr, 0 , sizeof(addr));
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0029-hybris-disable-the-usage-of-libprocessgroup-since-it.patch
+++ b/system/core/0029-hybris-disable-the-usage-of-libprocessgroup-since-it.patch
@@ -1,7 +1,7 @@
-From 06aa84209af8c18140a83c101cbf6c6c605ab21d Mon Sep 17 00:00:00 2001
+From d20f661f0ad17646fb740224a353848dd689ddc4 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:33:03 +0200
-Subject: [PATCH 29/37] (hybris) disable the usage of libprocessgroup, since it
+Subject: [PATCH 29/39] (hybris) disable the usage of libprocessgroup, since it
  is incompatible.
 
 Change-Id: Ie37ac0dcc5cabbf33de55c148009fdfff3e90c64
@@ -12,7 +12,7 @@ Change-Id: Ie37ac0dcc5cabbf33de55c148009fdfff3e90c64
  3 files changed, 11 insertions(+), 7 deletions(-)
 
 diff --git a/init/Android.bp b/init/Android.bp
-index 70a4ac6..4aa23cd 100644
+index 63c8382a4..3b6f46f53 100644
 --- a/init/Android.bp
 +++ b/init/Android.bp
 @@ -79,7 +79,6 @@ cc_defaults {
@@ -23,7 +23,7 @@ index 70a4ac6..4aa23cd 100644
          "libavb",
          "libkeyutils",
          "libprotobuf-cpp-lite",
-@@ -220,7 +219,6 @@ cc_binary {
+@@ -221,7 +220,6 @@ cc_binary {
      shared_libs: [
          "libprotobuf-cpp-lite",
          "libhidl-gen-utils",
@@ -32,7 +32,7 @@ index 70a4ac6..4aa23cd 100644
          "libcutils",
      ],
 diff --git a/init/Android.mk b/init/Android.mk
-index c4a6a50..d6fc5b5 100644
+index c4a6a50e5..d6fc5b5b9 100644
 --- a/init/Android.mk
 +++ b/init/Android.mk
 @@ -71,7 +71,6 @@ LOCAL_STATIC_LIBRARIES := \
@@ -44,7 +44,7 @@ index c4a6a50..d6fc5b5 100644
      libkeyutils \
      libprotobuf-cpp-lite \
 diff --git a/init/service.cpp b/init/service.cpp
-index 9c294af..c2d8a38 100644
+index 9c294af15..c2d8a383a 100644
 --- a/init/service.cpp
 +++ b/init/service.cpp
 @@ -36,7 +36,6 @@
@@ -97,5 +97,5 @@ index 9c294af..c2d8a38 100644
      NotifyStateChange("running");
      return Success();
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0030-hybris-disable-vendor-symlink.patch
+++ b/system/core/0030-hybris-disable-vendor-symlink.patch
@@ -1,7 +1,7 @@
-From 6a23196ba3dfb75bcd82ba27806a3976276e1148 Mon Sep 17 00:00:00 2001
+From 1ad8264c607093292b1a370e3dca4319d3edbb1e Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Thu, 7 Jun 2018 15:29:53 +0000
-Subject: [PATCH 30/37] (hybris) disable vendor symlink
+Subject: [PATCH 30/39] (hybris) disable vendor symlink
 
 Change-Id: I26a32268e2f3af7ab0550397900f7a3ef0edfae5
 ---
@@ -9,7 +9,7 @@ Change-Id: I26a32268e2f3af7ab0550397900f7a3ef0edfae5
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 85323a1..a79d1c4 100644
+index 8afcfcc67..d684f6007 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -52,7 +52,9 @@ on init
@@ -24,5 +24,5 @@ index 85323a1..a79d1c4 100644
      # Create energy-aware scheduler tuning nodes
      mkdir /dev/stune
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0031-hybris-ignore-mount-and-mkdir-tmp-commands-entirely.patch
+++ b/system/core/0031-hybris-ignore-mount-and-mkdir-tmp-commands-entirely.patch
@@ -1,7 +1,7 @@
-From 0cd904596a83b6e5df27de986fd73eaa55cd632b Mon Sep 17 00:00:00 2001
+From 2c6d226202d00f493e5be3c945daaa02ca9be791 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 27 Aug 2018 11:08:12 +0000
-Subject: [PATCH 31/37] (hybris) ignore "mount" and "mkdir /tmp" commands
+Subject: [PATCH 31/39] (hybris) ignore "mount" and "mkdir /tmp" commands
  entirely.
 
 mount is usually removed during build, but if the *.rc files are on
@@ -21,7 +21,7 @@ Change-Id: Iba637613c6a927098c947536e11348e269e1bef3
  1 file changed, 16 insertions(+)
 
 diff --git a/init/builtins.cpp b/init/builtins.cpp
-index 8bb7b0f..23efc95 100644
+index 8bb7b0f0c..23efc95b0 100644
 --- a/init/builtins.cpp
 +++ b/init/builtins.cpp
 @@ -243,6 +243,13 @@ static Result<Success> do_insmod(const BuiltinArguments& args) {
@@ -73,5 +73,5 @@ index 8bb7b0f..23efc95 100644
  
  /* Imports .rc files from the specified paths. Default ones are applied if none is given.
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0032-hybris-Fix-actdead-charging-animation.-MER-1949.patch
+++ b/system/core/0032-hybris-Fix-actdead-charging-animation.-MER-1949.patch
@@ -1,17 +1,17 @@
-From 539fc0ac9e01cdd4ea15d0293b19fdb8d0035427 Mon Sep 17 00:00:00 2001
+From 80c4085b93c882819850fe06c6d9722cb3fef48a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Thu, 30 Aug 2018 19:54:16 +0300
-Subject: [PATCH 32/37] (hybris) Fix actdead charging animation. MER#1949
+Subject: [PATCH 32/39] (hybris) Fix actdead charging animation. MER#1949
 
 ---
  rootdir/init.rc | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index a79d1c4..06e110d 100644
+index d684f6007..8556f9acd 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
-@@ -699,7 +699,7 @@ on property:droid.late_start=trigger_late_start
+@@ -700,7 +700,7 @@ on property:droid.late_start=trigger_late_start
      class_start late_start
  
  on charger
@@ -21,5 +21,5 @@ index a79d1c4..06e110d 100644
  on property:vold.decrypt=trigger_reset_main
      class_reset main
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0033-hybris-system-core-Disable-usb-config.patch
+++ b/system/core/0033-hybris-system-core-Disable-usb-config.patch
@@ -1,7 +1,7 @@
-From 5221117d0094d2d8e25ab8cc35c8a35b48117ba3 Mon Sep 17 00:00:00 2001
+From e9ff4372646599d677d9fd0f127fc5047880d4f2 Mon Sep 17 00:00:00 2001
 From: Matti Kosola <matti.kosola@jolla.com>
 Date: Tue, 21 Feb 2017 13:13:26 +0100
-Subject: [PATCH 33/37] (hybris)[system/core] Disable usb config.
+Subject: [PATCH 33/39] (hybris)[system/core] Disable usb config.
 
 Signed-off-by: Matti Kosola <matti.kosola@jolla.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Matti Kosola <matti.kosola@jolla.com>
  1 file changed, 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 06e110d..90de916 100644
+index 8556f9acd..0acebed78 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -14,7 +14,6 @@ import /init.environ.rc
@@ -21,5 +21,5 @@ index 06e110d..90de916 100644
  
  on early-init
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0034-hybris-Remove-sbin-from-droid-PATH.patch
+++ b/system/core/0034-hybris-Remove-sbin-from-droid-PATH.patch
@@ -1,14 +1,14 @@
-From 49a9871ffcc6c78629e30d1fd4cd412757eefcaf Mon Sep 17 00:00:00 2001
+From f8a08335fe5d042424a848f562066f084257c107 Mon Sep 17 00:00:00 2001
 From: Jussi Laakkonen <jussi.laakkonen@jolla.com>
 Date: Wed, 31 Jan 2018 17:12:14 +0200
-Subject: [PATCH 34/37] (hybris) Remove /sbin from droid PATH.
+Subject: [PATCH 34/39] (hybris) Remove /sbin from droid PATH.
 
 ---
  rootdir/init.environ.rc.in | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/rootdir/init.environ.rc.in b/rootdir/init.environ.rc.in
-index 516dc82..90c2b64 100644
+index 516dc82f6..90c2b64d6 100644
 --- a/rootdir/init.environ.rc.in
 +++ b/rootdir/init.environ.rc.in
 @@ -1,7 +1,7 @@
@@ -21,5 +21,5 @@ index 516dc82..90c2b64 100644
      # Hopefully now it is - ghosalmartin
      # this breaks mixed 32/64-bit devices -mal
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0035-hybris-Fix-return-value-type-of-mount-command.patch
+++ b/system/core/0035-hybris-Fix-return-value-type-of-mount-command.patch
@@ -1,7 +1,7 @@
-From ca5cae9dac7d2e243ab08868196aa6014266fabe Mon Sep 17 00:00:00 2001
+From eb37a14cdac5c6d8bc42ace39dc6e6273af99360 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Sun, 18 Nov 2018 18:51:22 +0200
-Subject: [PATCH 35/37] (hybris) Fix return value type of mount command.
+Subject: [PATCH 35/39] (hybris) Fix return value type of mount command.
 
 Change-Id: Ib759e1be92d110863e43f13f7317372c6182a02d
 ---
@@ -9,7 +9,7 @@ Change-Id: Ib759e1be92d110863e43f13f7317372c6182a02d
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/init/builtins.cpp b/init/builtins.cpp
-index 23efc95..4e2bce3 100644
+index 23efc95b0..4e2bce361 100644
 --- a/init/builtins.cpp
 +++ b/init/builtins.cpp
 @@ -589,7 +589,7 @@ static Result<Success> do_mount_all(const BuiltinArguments& args) {
@@ -22,5 +22,5 @@ index 23efc95..4e2bce3 100644
  
      if (import_rc) {
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0036-hybris-disable-some-more-selinux-functionality.patch
+++ b/system/core/0036-hybris-disable-some-more-selinux-functionality.patch
@@ -1,7 +1,7 @@
-From 44a0b628b778be7df54c7f58276685233db80dfc Mon Sep 17 00:00:00 2001
+From d7bfc109f9a23d89e476011c63bde3fe50682d72 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <f_haider@gmx.at>
 Date: Thu, 28 Mar 2019 12:46:12 -0400
-Subject: [PATCH 36/37] (hybris) disable some more selinux functionality.
+Subject: [PATCH 36/39] (hybris) disable some more selinux functionality.
 
 Change-Id: Ie63eb13b73d626668b32041fec4400cf2edd2fe5
 ---
@@ -11,7 +11,7 @@ Change-Id: Ie63eb13b73d626668b32041fec4400cf2edd2fe5
  3 files changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/init/property_service.cpp b/init/property_service.cpp
-index 5bead05..f0d3453 100644
+index 5bead058c..f0d345326 100644
 --- a/init/property_service.cpp
 +++ b/init/property_service.cpp
 @@ -338,11 +338,14 @@ class SocketConnection {
@@ -30,7 +30,7 @@ index 5bead05..f0d3453 100644
  
    private:
 diff --git a/init/subcontext.cpp b/init/subcontext.cpp
-index fdb4641..5fbe8fc 100644
+index fdb46415d..5fbe8fc40 100644
 --- a/init/subcontext.cpp
 +++ b/init/subcontext.cpp
 @@ -243,11 +243,11 @@ void Subcontext::Fork() {
@@ -48,7 +48,7 @@ index fdb4641..5fbe8fc 100644
          auto child_fd_string = std::to_string(child_fd);
          const char* args[] = {init_path.c_str(), "subcontext", context_.c_str(),
 diff --git a/init/util.cpp b/init/util.cpp
-index e27f4f8..a5c95df 100644
+index e27f4f88e..a5c95df5b 100644
 --- a/init/util.cpp
 +++ b/init/util.cpp
 @@ -117,10 +117,12 @@ int CreateSocket(const char* name, int type, bool passcred, mode_t perm, uid_t u
@@ -77,5 +77,5 @@ index e27f4f8..a5c95df 100644
      if (ret) {
          errno = savederrno;
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0037-hybris-Disable-mnt-tmpfs-creation.patch
+++ b/system/core/0037-hybris-Disable-mnt-tmpfs-creation.patch
@@ -1,7 +1,7 @@
-From 700cd471d926592199e36657e51a46f975ea1362 Mon Sep 17 00:00:00 2001
+From b7333f2978cb4031d4366da49413bd347dcda922 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 3 Jun 2019 13:46:44 +0200
-Subject: [PATCH 37/37] (hybris) Disable /mnt tmpfs creation
+Subject: [PATCH 37/39] (hybris) Disable /mnt tmpfs creation
 
 Change-Id: I7c4fb119475adc345104f6ac5a68b578b6b2d433
 ---
@@ -9,10 +9,10 @@ Change-Id: I7c4fb119475adc345104f6ac5a68b578b6b2d433
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index 1ffa036..414c53d 100644
+index 214c62215..7fe36d504 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
-@@ -600,8 +600,8 @@ int main(int argc, char** argv) {
+@@ -601,8 +601,8 @@ int main(int argc, char** argv) {
  
          // Mount staging areas for devices managed by vold
          // See storage config details at http://source.android.com/devices/storage/
@@ -24,5 +24,5 @@ index 1ffa036..414c53d 100644
          // part of the vendor partition, e.g. because they are mounted read-write.
          mkdir("/mnt/vendor", 0755);
 -- 
-2.7.4
+2.17.1
 

--- a/system/core/0038-hybris-Disable-init_user0-which-is-not-needed-on-Mer.patch
+++ b/system/core/0038-hybris-Disable-init_user0-which-is-not-needed-on-Mer.patch
@@ -1,17 +1,17 @@
-From 77aa75a70e53c836b7dc416f2f40cab25693e125 Mon Sep 17 00:00:00 2001
+From 75df6c383da1e1fc3875a2705aa51d58aa614b8a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@jolla.com>
 Date: Mon, 10 Dec 2018 12:11:06 +0200
-Subject: [PATCH] (hybris) Disable init_user0 which is not needed on Mer.
+Subject: [PATCH 38/39] (hybris) Disable init_user0 which is not needed on Mer.
 
 ---
  rootdir/init.rc | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 3c28b010f..b829be4ca 100644
+index 0acebed78..085ff1c8e 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
-@@ -544,7 +544,8 @@ on post-fs-data
+@@ -546,7 +546,8 @@ on post-fs-data
      mkdir /data/cache/backup_stage 0700 system system
      mkdir /data/cache/backup 0700 system system
  

--- a/system/core/0039-hybris-Disable-SELinux-init.patch
+++ b/system/core/0039-hybris-Disable-SELinux-init.patch
@@ -1,7 +1,7 @@
-From 35e6c56e5c3270fd0d243b320bc24e06bf7f9f02 Mon Sep 17 00:00:00 2001
+From 1a59756b52362c0dfc9eee2e8cf1728726d1f2f9 Mon Sep 17 00:00:00 2001
 From: Matti Kosola <matti.kosola@jolla.com>
 Date: Wed, 4 Sep 2019 12:07:34 +0200
-Subject: [PATCH] (hybris) Disable SELinux init.
+Subject: [PATCH 39/39] (hybris) Disable SELinux init.
 
 Sailfish OS SELinux initialization is done by systemd.
 Conflicting init has been resolved by disabling SELinux
@@ -14,7 +14,7 @@ Signed-off-by: Matti Kosola <matti.kosola@jolla.com>
  1 file changed, 8 insertions(+)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index 7fe36d5..ce2100c 100644
+index 7fe36d504..ce2100c57 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
 @@ -70,6 +70,8 @@ using android::base::StringPrintf;
@@ -66,5 +66,5 @@ index 7fe36d5..ce2100c 100644
      epoll_fd = epoll_create1(EPOLL_CLOEXEC);
      if (epoll_fd == -1) {
 -- 
-2.7.4
+2.17.1
 


### PR DESCRIPTION
[hybris-patches] reach main init state by setting vold property. JB#47375

If we do class_start in the on boot section it might happen too early and cause modem issues.

Doing it when vold starts (or should start, we disable it) is closer to the proper sequence of events.