### PR TITLE
apply-patches: Stop signing hybris-patches with GPG keys only on host

### DIFF
--- a/apply-patches.sh
+++ b/apply-patches.sh
@@ -21,7 +21,7 @@ else
     MBS=$(find . -name *.patch -exec dirname {} \; |sort -u)
     for mb in $MBS; do
         cd $OLD_WD/$mb
-        git am $OLD_WD/hybris-patches/$mb/*.patch
+        git am --no-gpg-sign $OLD_WD/hybris-patches/$mb/*.patch
     done
 fi
 


### PR DESCRIPTION
I have GPG signing of my git commits enabled and the GPG key isn't available out-of-the-box on the HABUILD environment -> apply-patches used to always fail and I had to copy the key over manually when setting things up OR disable GPG signing altogether in ~/.gitconfig temporarily.
We don't *really* need to sign temporary patches that get lost on another resync anyway, do we?