### PR TITLE
hybris-patches: Allow input group to use vibrator.

### DIFF
--- a/bionic/0001-hybris-Fix-__get_tls-and-related-functions-Android-8.patch
+++ b/bionic/0001-hybris-Fix-__get_tls-and-related-functions-Android-8.patch
@@ -134,7 +134,7 @@ new file mode 100644
 index 000000000..4a8fa5fc2
 --- /dev/null
 +++ b/libc/private/__get_tls_internal.h
-@@ -0,0 +1,54 @@
+@@ -0,0 +1,53 @@
 +/*
 + * Copyright (C) 2008 The Android Open Source Project
 + * All rights reserved.
@@ -188,7 +188,6 @@ index 000000000..4a8fa5fc2
 +#endif
 +
 +#endif /* __BIONIC_PRIVATE_GET_TLS_INTERNAL_H_ */
-+
 -- 
 2.17.1
 

--- a/bionic/0005-hybris-Fix-TLS-slots-for-x86-Aligns-with-this-libhyb.patch
+++ b/bionic/0005-hybris-Fix-TLS-slots-for-x86-Aligns-with-this-libhyb.patch
@@ -20,7 +20,7 @@ index af4d4d07c..07590f60c 100644
 -  TLS_SLOT_ERRNO = 5,
 +
 +  TLS_SLOT_STACK_GUARD = 5, // GCC requires this specific slot for x86.
-+  
++
 +  TLS_SLOT_ERRNO,
  
    // These two aren't used by bionic itself, but allow the graphics code to

--- a/system/core/0001-hybris-Add-usr-libexec-droid-hybris-lib-dev-alog-to-.patch
+++ b/system/core/0001-hybris-Add-usr-libexec-droid-hybris-lib-dev-alog-to-.patch
@@ -1,7 +1,7 @@
 From 1477031466c0bc447e48201914ba054237a98427 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 6 Nov 2013 21:09:30 +0000
-Subject: [PATCH 01/39] (hybris) Add /usr/libexec/droid-hybris/lib-dev-alog/ to
+Subject: [PATCH 01/40] (hybris) Add /usr/libexec/droid-hybris/lib-dev-alog/ to
  the LD_LIBRARY_PATH for all init'ed binaries to support the /dev/alog used in
  Mer
 

--- a/system/core/0002-hybris-Don-t-create-mount-dev-proc-sys.-when-booting.patch
+++ b/system/core/0002-hybris-Don-t-create-mount-dev-proc-sys.-when-booting.patch
@@ -1,7 +1,7 @@
 From b422706d9a7ad022f177a464c8037e088db0a8a1 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 8 Oct 2013 16:59:30 +0100
-Subject: [PATCH 02/39] (hybris) Don't create/mount dev/proc/sys... when
+Subject: [PATCH 02/40] (hybris) Don't create/mount dev/proc/sys... when
  booting with Mer
 
 Change-Id: I16afd5bf56ee3e36f09b3496b80e356ce9269a64

--- a/system/core/0003-hybris-Mer-can-specify-mis-alignment-handling-this-i.patch
+++ b/system/core/0003-hybris-Mer-can-specify-mis-alignment-handling-this-i.patch
@@ -1,7 +1,7 @@
 From f1042f1347d6b25674f4e121c093b8e06c2e596a Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:07:56 +0100
-Subject: [PATCH 03/39] (hybris) Mer can specify mis-alignment handling - this
+Subject: [PATCH 03/40] (hybris) Mer can specify mis-alignment handling - this
  is the wrong place to set it
 
 Change-Id: Ib46c0a0b6d285dbcd05736e7ba9e9fd0a0480984

--- a/system/core/0004-hybris-Mount-points-are-handled-by-Mer.patch
+++ b/system/core/0004-hybris-Mount-points-are-handled-by-Mer.patch
@@ -1,7 +1,7 @@
 From d64f7020d3ddeda18d1db6e7610d7d046d675b13 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:09:20 +0100
-Subject: [PATCH 04/39] (hybris) Mount points are handled by Mer
+Subject: [PATCH 04/40] (hybris) Mount points are handled by Mer
 
 Change-Id: I295b30a47b6e147b037275032a00b304085fe711
 ---

--- a/system/core/0005-hybris-Systemd-handles-control-groups.patch
+++ b/system/core/0005-hybris-Systemd-handles-control-groups.patch
@@ -1,7 +1,7 @@
 From d5aa68ed1a6389211abd43df9e2c2109aabded31 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:10:16 +0100
-Subject: [PATCH 05/39] (hybris) Systemd handles control groups
+Subject: [PATCH 05/40] (hybris) Systemd handles control groups
 
 Change-Id: I92ef4b2389544906be32169c57176575eb1719ec
 ---

--- a/system/core/0006-hybris-Mer-uses-udev.patch
+++ b/system/core/0006-hybris-Mer-uses-udev.patch
@@ -1,7 +1,7 @@
 From 155e2d07aa0832b325f8f87300c97ef2128dde67 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:12:18 +0100
-Subject: [PATCH 06/39] (hybris) Mer uses udev
+Subject: [PATCH 06/40] (hybris) Mer uses udev
 
 Change-Id: I7588a80db2c77879fb56d5decfd055224f20ab54
 ---

--- a/system/core/0007-hybris-Add-a-ready-trigger-to-init-to-run-post-boot.patch
+++ b/system/core/0007-hybris-Add-a-ready-trigger-to-init-to-run-post-boot.patch
@@ -1,7 +1,7 @@
 From 5989860da7fbfb203719a06e28353fc6208ee772 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 20 Nov 2013 19:18:51 +0000
-Subject: [PATCH 07/39] (hybris) Add a ready trigger to init to run post boot
+Subject: [PATCH 07/40] (hybris) Add a ready trigger to init to run post boot
 
 Change-Id: I9c828463424c0e82c3de0159db08299e7ce6fe06
 ---

--- a/system/core/0008-hybris-Notify-Mer-s-systemd-that-we-re-done.patch
+++ b/system/core/0008-hybris-Notify-Mer-s-systemd-that-we-re-done.patch
@@ -13,7 +13,7 @@ diff --git a/rootdir/init.rc b/rootdir/init.rc
 index 5bed0e34b..7cb3685c0 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
-@@ -764,3 +764,13 @@ service flash_recovery /system/bin/install-recovery.sh
+@@ -764,3 +764,12 @@ service flash_recovery /system/bin/install-recovery.sh
  on property:persist.sys.recovery_update=true
      start flash_recovery
  
@@ -26,7 +26,6 @@ index 5bed0e34b..7cb3685c0 100644
 +service droid_init_done /bin/sh /usr/bin/droid/droid-init-done.sh
 +    class mer
 +    oneshot
-+
 -- 
 2.17.1
 

--- a/system/core/0008-hybris-Notify-Mer-s-systemd-that-we-re-done.patch
+++ b/system/core/0008-hybris-Notify-Mer-s-systemd-that-we-re-done.patch
@@ -1,7 +1,7 @@
 From 1849c79f3e1a1c90ee9b40e485725c77adf6a9c4 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 20 Nov 2013 19:24:31 +0000
-Subject: [PATCH 08/39] (hybris) Notify Mer's systemd that we're done
+Subject: [PATCH 08/40] (hybris) Notify Mer's systemd that we're done
 
 Change-Id: If6a16f43397f00c8e579af79ae6cf8459786e7b3
 Signed-off-by: David Greaves <david.greaves@jollamobile.com>

--- a/system/core/0009-hybris-Disable-usb-import.patch
+++ b/system/core/0009-hybris-Disable-usb-import.patch
@@ -1,7 +1,7 @@
 From 1adafb228c8d3e97c1b1a872b5972bbc476e7e91 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 19 Feb 2014 19:02:32 +0000
-Subject: [PATCH 09/39] (hybris) Disable usb import
+Subject: [PATCH 09/40] (hybris) Disable usb import
 
 Change-Id: I8aba60bc79fb4aab3854f0569b325ad69c5126d4
 Signed-off-by: David Greaves <david@dgreaves.com>

--- a/system/core/0010-hybris-allow-system-group-to-trigger-haptics.patch
+++ b/system/core/0010-hybris-allow-system-group-to-trigger-haptics.patch
@@ -1,7 +1,7 @@
 From 1ac7333536d0727b34e02fdc1899d62c8b28fdc0 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Thu, 13 Mar 2014 08:51:53 +0000
-Subject: [PATCH 10/39] (hybris) allow system group to trigger haptics
+Subject: [PATCH 10/40] (hybris) allow system group to trigger haptics
 
 Signed-off-by: Simonas Leleiva <simonas.leleiva@jollamobile.com>
 

--- a/system/core/0011-hybris-trigger-late_start-on-property-change.patch
+++ b/system/core/0011-hybris-trigger-late_start-on-property-change.patch
@@ -1,7 +1,7 @@
 From a2c9dd20ff97155006ca2bd4e2b06ea51d2d60aa Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Tue, 18 Mar 2014 14:07:11 +0000
-Subject: [PATCH 11/39] (hybris) trigger late_start on property change
+Subject: [PATCH 11/40] (hybris) trigger late_start on property change
 
 Android's late_start is triggered by mount_all, which also determines whether
 the /data partition is encrypted.

--- a/system/core/0012-hybris-property_service.c-adding-support-for-getprop.patch
+++ b/system/core/0012-hybris-property_service.c-adding-support-for-getprop.patch
@@ -1,7 +1,7 @@
 From 6e2d88cb450e05d1f77e579cb0b0e2249485d295 Mon Sep 17 00:00:00 2001
 From: Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
 Date: Thu, 31 Oct 2013 12:19:19 +0200
-Subject: [PATCH 12/39] (hybris) property_service.c: adding support for getprop
+Subject: [PATCH 12/40] (hybris) property_service.c: adding support for getprop
  and listprop
 
 Change-Id: Ie5fbdb55c48038ce8250f27500623b3b81cc5cd1

--- a/system/core/0013-hybris-reach-main-init-state.patch
+++ b/system/core/0013-hybris-reach-main-init-state.patch
@@ -1,7 +1,7 @@
 From c3a59d857892a951b870ccb4c3143004ed4a9946 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Sat, 22 Aug 2015 12:03:42 +0100
-Subject: [PATCH 13/39] (hybris) reach main init state
+Subject: [PATCH 13/40] (hybris) reach main init state
 
 Change-Id: I471f48afaebf91c92f0d2a7bd3a24c5d1fa58ecd
 ---

--- a/system/core/0014-hybris-Disable-setting-hostname-and-domainname-in-in.patch
+++ b/system/core/0014-hybris-Disable-setting-hostname-and-domainname-in-in.patch
@@ -1,7 +1,7 @@
 From 4ce1301cc8268a9d740a4619035c86dceceeb9c7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Sat, 6 Aug 2016 11:37:38 +0300
-Subject: [PATCH 14/39] (hybris) Disable setting hostname and domainname in
+Subject: [PATCH 14/40] (hybris) Disable setting hostname and domainname in
  init.rc.
 
 Change-Id: I5b9f59e80760e53636763c89f8f76f350c17b3ec

--- a/system/core/0015-hybris-Update-rootdir-for-64bit-libs.patch
+++ b/system/core/0015-hybris-Update-rootdir-for-64bit-libs.patch
@@ -1,7 +1,7 @@
 From fd87f13efe9db2fb1dcd29efb38d301eaa27be62 Mon Sep 17 00:00:00 2001
 From: Martin Ghosal <Martin.Ghosal@sky.uk>
 Date: Sat, 15 Oct 2016 15:38:47 +0100
-Subject: [PATCH 15/39] (hybris) Update rootdir for 64bit libs
+Subject: [PATCH 15/40] (hybris) Update rootdir for 64bit libs
 
 Change-Id: I593ae40da755c116bb28c96dcace863e6b30b4cc
 ---

--- a/system/core/0016-hybris-Disable-all-zygote-variations.patch
+++ b/system/core/0016-hybris-Disable-all-zygote-variations.patch
@@ -1,7 +1,7 @@
 From a08486cd09a2f222dd61032c123babe8db32ad3d Mon Sep 17 00:00:00 2001
 From: Martin Ghosal <Martin.Ghosal@sky.uk>
 Date: Sun, 8 Jan 2017 16:34:54 +0000
-Subject: [PATCH 16/39] (hybris) Disable all zygote variations
+Subject: [PATCH 16/40] (hybris) Disable all zygote variations
 
 Change-Id: Ie1ad26486f47b3bf67134db917b3c9e51536904c
 ---

--- a/system/core/0017-hybris-Disable-ueventd-service.patch
+++ b/system/core/0017-hybris-Disable-ueventd-service.patch
@@ -1,7 +1,7 @@
 From 1439cc542b25c8a45a59db6225f24c13a01f29f9 Mon Sep 17 00:00:00 2001
 From: Martin Ghosal <Martin.Ghosal@sky.uk>
 Date: Sun, 8 Jan 2017 17:16:08 +0000
-Subject: [PATCH 17/39] (hybris) Disable ueventd service
+Subject: [PATCH 17/40] (hybris) Disable ueventd service
 
 Change-Id: I8ee7b863a533f4a6ef7658ef1c1ef4bdb95d5d65
 ---

--- a/system/core/0018-hybris-Disable-SELinux.patch
+++ b/system/core/0018-hybris-Disable-SELinux.patch
@@ -1,7 +1,7 @@
 From 76b09fd6a855e9f1fa8a80c6fe7bf60a46c263a8 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Thu, 9 Feb 2017 21:48:19 +0200
-Subject: [PATCH 18/39] (hybris) Disable SELinux
+Subject: [PATCH 18/40] (hybris) Disable SELinux
 
 Change-Id: I0511b2a0de1b20996f4fb8e9f3569acb41e2cf0f
 ---

--- a/system/core/0019-hybris-Properly-handle-shutdown-from-Mer.patch
+++ b/system/core/0019-hybris-Properly-handle-shutdown-from-Mer.patch
@@ -12,10 +12,11 @@ diff --git a/rootdir/init.rc b/rootdir/init.rc
 index ae9cd7b08..28f0ca825 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
-@@ -788,3 +788,12 @@ service droid_init_done /bin/sh /usr/bin/droid/droid-init-done.sh
+@@ -787,3 +787,12 @@
+ service droid_init_done /bin/sh /usr/bin/droid/droid-init-done.sh
      class mer
      oneshot
- 
++
 +# Properly handle shutdown from Mer
 +on property:hybris.shutdown=*
 +    class_stop late_start
@@ -24,7 +25,6 @@ index ae9cd7b08..28f0ca825 100644
 +    class_stop hal
 +    class_stop early_hal
 +    class_stop core
-+
 -- 
 2.17.1
 

--- a/system/core/0019-hybris-Properly-handle-shutdown-from-Mer.patch
+++ b/system/core/0019-hybris-Properly-handle-shutdown-from-Mer.patch
@@ -1,7 +1,7 @@
 From e94d8cba8a43cb852949f386e3aed96a923afb53 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Sat, 8 Jul 2017 00:27:20 +0300
-Subject: [PATCH 19/39] (hybris) Properly handle shutdown from Mer.
+Subject: [PATCH 19/40] (hybris) Properly handle shutdown from Mer.
 
 Change-Id: I89daebb9559d38f3c639f4634c417252c7a92fe0
 ---

--- a/system/core/0020-hybris-Use-services-from-usr-libexec-droid-hybris-sy.patch
+++ b/system/core/0020-hybris-Use-services-from-usr-libexec-droid-hybris-sy.patch
@@ -1,7 +1,7 @@
 From c52e0c358eb27b2fccfab86a160f0c77e37a89e0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Thu, 9 Feb 2017 21:57:47 +0200
-Subject: [PATCH 20/39] (hybris) Use services from
+Subject: [PATCH 20/40] (hybris) Use services from
  /usr/libexec/droid-hybris/system/etc/init/.
 
 Change-Id: I6185781c2bd6a2db281201ad705394f4d6d24131

--- a/system/core/0021-hybris-Remove-LD_LIBRARY_PATH-from-init.environ.rc.patch
+++ b/system/core/0021-hybris-Remove-LD_LIBRARY_PATH-from-init.environ.rc.patch
@@ -1,7 +1,7 @@
 From d0229a40ad25575ad40f23434ed09f8eb5385458 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Tue, 17 Oct 2017 21:58:40 +0300
-Subject: [PATCH 21/39] (hybris) Remove LD_LIBRARY_PATH from init.environ.rc
+Subject: [PATCH 21/40] (hybris) Remove LD_LIBRARY_PATH from init.environ.rc
 
 Change-Id: I52a2c733f609f90b6ac31be72a4f8fe7681beac0
 ---

--- a/system/core/0022-hybris-define-32-bit-LD_LIBRARY_PATH-for-32-bit-devi.patch
+++ b/system/core/0022-hybris-define-32-bit-LD_LIBRARY_PATH-for-32-bit-devi.patch
@@ -1,7 +1,7 @@
 From bd88af2919d6f2552fa3b23bc0b9d71ebefd9514 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jollamobile.com>
 Date: Wed, 25 Oct 2017 14:14:59 +0300
-Subject: [PATCH 22/39] (hybris) define 32-bit LD_LIBRARY_PATH for 32-bit
+Subject: [PATCH 22/40] (hybris) define 32-bit LD_LIBRARY_PATH for 32-bit
  devices
 
 ---

--- a/system/core/0023-hybris-Fix-list-and-get-properties.patch
+++ b/system/core/0023-hybris-Fix-list-and-get-properties.patch
@@ -1,7 +1,7 @@
 From 2f7534c465019370db8adae00a3b147cb50a720d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Tue, 16 Jan 2018 16:18:31 +0200
-Subject: [PATCH 23/39] (hybris) Fix list and get properties.
+Subject: [PATCH 23/40] (hybris) Fix list and get properties.
 
 Change-Id: I9deb65f147e941fc5c9f91793f851440d02260e1
 ---

--- a/system/core/0024-hybris-more-SELinux-disablement.patch
+++ b/system/core/0024-hybris-more-SELinux-disablement.patch
@@ -1,7 +1,7 @@
 From ff19de6a3f841f39d22310a4ae5d04d03997d008 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Wed, 18 Apr 2018 18:49:02 +0200
-Subject: [PATCH 24/39] (hybris) more SELinux disablement
+Subject: [PATCH 24/40] (hybris) more SELinux disablement
 
 Change-Id: Ic1bc474e993f2b66ab9114e88d7ec4f718a99d5c
 Signed-off-by: Simonas Leleiva <simonas.leleiva@meramo.co.uk>

--- a/system/core/0025-hybris-don-t-try-to-mount-since-mer-handles-this.patch
+++ b/system/core/0025-hybris-don-t-try-to-mount-since-mer-handles-this.patch
@@ -1,7 +1,7 @@
 From 1f7726dfc49825657fa7786e27b2adb2f459b623 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 4 Jun 2018 10:00:13 +0200
-Subject: [PATCH 25/39] (hybris) don't try to mount since mer handles this
+Subject: [PATCH 25/40] (hybris) don't try to mount since mer handles this
 
 Change-Id: I305ac649fd199ef11a8d88d350f1fc06171bc0ba
 ---

--- a/system/core/0026-hybris-avoid-attempting-to-mount-partitions-mer-syst.patch
+++ b/system/core/0026-hybris-avoid-attempting-to-mount-partitions-mer-syst.patch
@@ -1,7 +1,7 @@
 From c385ba2020d6479dd530100925736d67ec9442c0 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:28:27 +0200
-Subject: [PATCH 26/39] (hybris) avoid attempting to mount partitions,
+Subject: [PATCH 26/40] (hybris) avoid attempting to mount partitions,
  mer/systemd handles this
 
 Even partitions weren't mounted by this previously it still would produce an

--- a/system/core/0027-hybris-load-services-from-droid-hybris-as-early-as-p.patch
+++ b/system/core/0027-hybris-load-services-from-droid-hybris-as-early-as-p.patch
@@ -1,7 +1,7 @@
 From 26133bb98b735c422674c60aec13865554a03e90 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:30:01 +0200
-Subject: [PATCH 27/39] (hybris) load services from droid-hybris as early as
+Subject: [PATCH 27/40] (hybris) load services from droid-hybris as early as
  possible
 
 This makes sure our service definitions are loaded first and can be used to

--- a/system/core/0028-hybris-disable-remnants-of-SELinux-which-currently-b.patch
+++ b/system/core/0028-hybris-disable-remnants-of-SELinux-which-currently-b.patch
@@ -1,7 +1,7 @@
 From 3a64af0e06c236586d0e8524704b1789c22f405c Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:32:06 +0200
-Subject: [PATCH 28/39] (hybris) disable remnants of SELinux which currently
+Subject: [PATCH 28/40] (hybris) disable remnants of SELinux which currently
  break
 
 Change-Id: I252a8399c9853d993fc17d769bfbb2e4c722cfe8

--- a/system/core/0029-hybris-disable-the-usage-of-libprocessgroup-since-it.patch
+++ b/system/core/0029-hybris-disable-the-usage-of-libprocessgroup-since-it.patch
@@ -1,7 +1,7 @@
 From 0c0d6836c726ea40a3bfc40595a356e4b84b21a9 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:33:03 +0200
-Subject: [PATCH 29/39] (hybris) disable the usage of libprocessgroup, since it
+Subject: [PATCH 29/40] (hybris) disable the usage of libprocessgroup, since it
  is incompatible.
 
 Change-Id: Ie37ac0dcc5cabbf33de55c148009fdfff3e90c64

--- a/system/core/0030-hybris-disable-vendor-symlink.patch
+++ b/system/core/0030-hybris-disable-vendor-symlink.patch
@@ -1,7 +1,7 @@
 From 84d69d03abe1c6f711d7551b74c03d892745f068 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Thu, 7 Jun 2018 15:29:53 +0000
-Subject: [PATCH 30/39] (hybris) disable vendor symlink
+Subject: [PATCH 30/40] (hybris) disable vendor symlink
 
 Change-Id: I26a32268e2f3af7ab0550397900f7a3ef0edfae5
 ---

--- a/system/core/0031-hybris-ignore-mount-and-mkdir-tmp-commands-entirely.patch
+++ b/system/core/0031-hybris-ignore-mount-and-mkdir-tmp-commands-entirely.patch
@@ -1,7 +1,7 @@
 From 7d4d7514ffeba53b8697a426c20118d34a241ea4 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 27 Aug 2018 11:08:12 +0000
-Subject: [PATCH 31/39] (hybris) ignore "mount" and "mkdir /tmp" commands
+Subject: [PATCH 31/40] (hybris) ignore "mount" and "mkdir /tmp" commands
  entirely.
 
 mount is usually removed during build, but if the *.rc files are on

--- a/system/core/0032-hybris-Fix-actdead-charging-animation.-MER-1949.patch
+++ b/system/core/0032-hybris-Fix-actdead-charging-animation.-MER-1949.patch
@@ -1,7 +1,7 @@
 From 71a7301555b2af4b2d457b9828174fd502e8350a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Thu, 30 Aug 2018 19:54:16 +0300
-Subject: [PATCH 32/39] (hybris) Fix actdead charging animation. MER#1949
+Subject: [PATCH 32/40] (hybris) Fix actdead charging animation. MER#1949
 
 ---
  rootdir/init.rc | 2 +-

--- a/system/core/0033-hybris-system-core-Disable-usb-config.patch
+++ b/system/core/0033-hybris-system-core-Disable-usb-config.patch
@@ -1,7 +1,7 @@
 From fb88c0afbacd9a1827979dc8b09761639281cea6 Mon Sep 17 00:00:00 2001
 From: Matti Kosola <matti.kosola@jolla.com>
 Date: Tue, 21 Feb 2017 13:13:26 +0100
-Subject: [PATCH 33/39] (hybris)[system/core] Disable usb config.
+Subject: [PATCH 33/40] (hybris)[system/core] Disable usb config.
 
 Signed-off-by: Matti Kosola <matti.kosola@jolla.com>
 ---

--- a/system/core/0034-hybris-Remove-sbin-from-droid-PATH.patch
+++ b/system/core/0034-hybris-Remove-sbin-from-droid-PATH.patch
@@ -1,7 +1,7 @@
 From 25929384dc9482df6671dc5da24c87b3fd32f1dd Mon Sep 17 00:00:00 2001
 From: Jussi Laakkonen <jussi.laakkonen@jolla.com>
 Date: Wed, 31 Jan 2018 17:12:14 +0200
-Subject: [PATCH 34/39] (hybris) Remove /sbin from droid PATH.
+Subject: [PATCH 34/40] (hybris) Remove /sbin from droid PATH.
 
 ---
  rootdir/init.environ.rc.in | 2 +-

--- a/system/core/0035-hybris-Fix-return-value-type-of-mount-command.patch
+++ b/system/core/0035-hybris-Fix-return-value-type-of-mount-command.patch
@@ -1,7 +1,7 @@
 From 216c77867e2fb723037fbd362492e09ccb02e14c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Sun, 18 Nov 2018 18:51:22 +0200
-Subject: [PATCH 35/39] (hybris) Fix return value type of mount command.
+Subject: [PATCH 35/40] (hybris) Fix return value type of mount command.
 
 Change-Id: Ib759e1be92d110863e43f13f7317372c6182a02d
 ---

--- a/system/core/0036-hybris-disable-some-more-selinux-functionality.patch
+++ b/system/core/0036-hybris-disable-some-more-selinux-functionality.patch
@@ -1,7 +1,7 @@
 From 04972b397b8a2754b9a4c0e5d91bf1c8acc312e1 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <f_haider@gmx.at>
 Date: Thu, 28 Mar 2019 12:46:12 -0400
-Subject: [PATCH 36/39] (hybris) disable some more selinux functionality.
+Subject: [PATCH 36/40] (hybris) disable some more selinux functionality.
 
 Change-Id: Ie63eb13b73d626668b32041fec4400cf2edd2fe5
 ---

--- a/system/core/0037-hybris-Disable-mnt-tmpfs-creation.patch
+++ b/system/core/0037-hybris-Disable-mnt-tmpfs-creation.patch
@@ -1,7 +1,7 @@
 From 6e99887c6e32a66b60f3de71a71702d908debc5f Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 3 Jun 2019 13:46:44 +0200
-Subject: [PATCH 37/39] (hybris) Disable /mnt tmpfs creation
+Subject: [PATCH 37/40] (hybris) Disable /mnt tmpfs creation
 
 Change-Id: I7c4fb119475adc345104f6ac5a68b578b6b2d433
 ---

--- a/system/core/0038-hybris-Disable-init_user0-which-is-not-needed-on-Mer.patch
+++ b/system/core/0038-hybris-Disable-init_user0-which-is-not-needed-on-Mer.patch
@@ -1,7 +1,7 @@
 From 8ab5e607e71ac798d0a8b2045492a55d6b273534 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@jolla.com>
 Date: Mon, 10 Dec 2018 12:11:06 +0200
-Subject: [PATCH 38/39] (hybris) Disable init_user0 which is not needed on Mer.
+Subject: [PATCH 38/40] (hybris) Disable init_user0 which is not needed on Mer.
 
 ---
  rootdir/init.rc | 3 ++-

--- a/system/core/0039-hybris-Allow-input-group-to-use-vibrator.patch
+++ b/system/core/0039-hybris-Allow-input-group-to-use-vibrator.patch
@@ -1,0 +1,37 @@
+From e1ca562a7e324885fa14dd58651bc622ebd6f9cc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
+ <juho.hamalainen@jolla.com>
+Date: Mon, 23 Mar 2020 17:40:04 +0200
+Subject: [PATCH 39/40] (hybris) Allow input group to use vibrator.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+[hybris] Allow input group to use vibrator. JB#49350
+
+Signed-off-by: Juho Hämäläinen <juho.hamalainen@jolla.com>
+---
+ rootdir/init.rc | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/rootdir/init.rc b/rootdir/init.rc
+index c5a6a0bc0..b2f6540ab 100644
+--- a/rootdir/init.rc
++++ b/rootdir/init.rc
+@@ -649,10 +649,11 @@ on boot
+     chown system system /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
+     chmod 0660 /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
+ 
++    # SailfishOS: allow input group to use vibrator
++    chown system input /sys/class/leds/vibrator/activate
++    chown system input /sys/class/leds/vibrator/duration
+     chown system system /sys/class/leds/vibrator/trigger
+-    chown system system /sys/class/leds/vibrator/activate
+     chown system system /sys/class/leds/vibrator/brightness
+-    chown system system /sys/class/leds/vibrator/duration
+     chown system system /sys/class/leds/vibrator/state
+     chown system system /sys/class/timed_output/vibrator/enable
+     chown system system /sys/class/leds/keyboard-backlight/brightness
+-- 
+2.20.1
+

--- a/system/core/0040-hybris-Allow-input-group-to-use-old-vibrator.patch
+++ b/system/core/0040-hybris-Allow-input-group-to-use-old-vibrator.patch
@@ -1,0 +1,31 @@
+From 324315555140ca5fb378286dcd166f9750cba627 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
+ <juho.hamalainen@jolla.com>
+Date: Tue, 24 Mar 2020 14:07:40 +0200
+Subject: [PATCH 40/40] (hybris) Allow input group to use old vibrator.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Juho Hämäläinen <juho.hamalainen@jolla.com>
+---
+ rootdir/init.rc | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/rootdir/init.rc b/rootdir/init.rc
+index b2f6540ab..e33f89132 100644
+--- a/rootdir/init.rc
++++ b/rootdir/init.rc
+@@ -655,7 +655,8 @@ on boot
+     chown system system /sys/class/leds/vibrator/trigger
+     chown system system /sys/class/leds/vibrator/brightness
+     chown system system /sys/class/leds/vibrator/state
+-    chown system system /sys/class/timed_output/vibrator/enable
++    # SailfishOS: allow input group to use vibrator
++    chown system input /sys/class/timed_output/vibrator/enable
+     chown system system /sys/class/leds/keyboard-backlight/brightness
+     chown system system /sys/class/leds/lcd-backlight/brightness
+     chown system system /sys/class/leds/button-backlight/brightness
+-- 
+2.20.1
+


### PR DESCRIPTION
Allow input group to use vibrator; e7945e0 implements #5 for the [hybris-16.0](https://github.com/mer-hybris/hybris-patches/tree/hybris-16.0) branch as these patches are required for working vibrator under Sailfish OS 3.3.0.

Since I also noticed the following 4 warnings when testing things, I decided to fix them with 35aac6a as well :)
```
$ hybris-patches/apply-patches.sh --mb
Applying: (hybris) Fix __get_tls and related functions (>=Android 8)
.git/rebase-apply/patch:183: new blank line at EOF.
+
warning: 1 line adds whitespace errors.
Applying: (hybris) Add support for get and list of properties.
...
Applying: (hybris) Fix TLS slots for x86 Aligns with this libhybris patch: https://github.com/libhybris/libhybris/pull/370
.git/rebase-apply/patch:16: trailing whitespace.
  
warning: 1 line adds whitespace errors.
Applying: (hybris) don't fail because of fsetxattr
...
Applying: (hybris) Notify Mer's systemd that we're done
.git/rebase-apply/patch:22: new blank line at EOF.
+
warning: 1 line adds whitespace errors.
Applying: (hybris) Disable usb import
...
Applying: (hybris) Properly handle shutdown from Mer.
.git/rebase-apply/patch:21: new blank line at EOF.
+
warning: 1 line adds whitespace errors.
Applying: (hybris) Use services from /usr/libexec/droid-hybris/system/etc/init/.
...
```