### PR TITLE
hybris-patches: Remove /dev/cg2_bpf cgroup device.

### DIFF
--- a/bionic/0001-hybris-Fix-__get_tls-and-related-functions-Android-8.patch
+++ b/bionic/0001-hybris-Fix-__get_tls-and-related-functions-Android-8.patch
@@ -1,8 +1,7 @@
-From 37ff1a6589ca177efdeff77ca046f52074f0bc43 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jollamobile.com>
 Date: Thu, 1 Feb 2018 00:57:52 +0000
-Subject: [PATCH 1/6] (hybris) Fix __get_tls and related functions (>=Android
- 8)
+Subject: [PATCH] (hybris) Fix __get_tls and related functions (>=Android 8)
 
 Change-Id: If75e4ae739ec6c482a68b1b69c2130535add2279
 Signed-off-by: Simonas Leleiva <simonas.leleiva@jollamobile.com>

--- a/bionic/0002-hybris-Add-support-for-get-and-list-of-properties.patch
+++ b/bionic/0002-hybris-Add-support-for-get-and-list-of-properties.patch
@@ -1,7 +1,7 @@
-From d6b0d88fd16ed59bc56d0d1fa41b054686fc1f81 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Sun, 17 Dec 2017 00:16:16 +0200
-Subject: [PATCH 2/6] (hybris) Add support for get and list of properties.
+Subject: [PATCH] (hybris) Add support for get and list of properties.
 
 Change-Id: I089a2a146c06d8ad0c234f0a9a4b5aa07beaeed5
 ---

--- a/bionic/0003-hybris-bionic_tls.h-shifting-TLS-slots-to-avoid-conf.patch
+++ b/bionic/0003-hybris-bionic_tls.h-shifting-TLS-slots-to-avoid-conf.patch
@@ -1,8 +1,8 @@
-From 5b22181f0316b519b1712b1f291d2f83bccba640 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
 Date: Thu, 9 Jan 2014 00:57:01 -0200
-Subject: [PATCH 3/6] (hybris) bionic_tls.h: shifting TLS slots to avoid
- conflicts with libc/hybris
+Subject: [PATCH] (hybris) bionic_tls.h: shifting TLS slots to avoid conflicts
+ with libc/hybris
 
 Change-Id: Idf503fe8fa0a24edf4dbbabaa8d3a1c2d1f60295
 Signed-off-by: Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>

--- a/bionic/0004-hybris-disable-tls-usage-in-locale.cpp-to-avoid-prob.patch
+++ b/bionic/0004-hybris-disable-tls-usage-in-locale.cpp-to-avoid-prob.patch
@@ -1,8 +1,8 @@
-From 78c3feee4abb30c1ddcb43c9d0dadd9b53872f54 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Wed, 18 Apr 2018 18:37:09 +0200
-Subject: [PATCH 4/6] (hybris) disable tls usage in locale.cpp, to avoid
- problems with libhybris
+Subject: [PATCH] (hybris) disable tls usage in locale.cpp, to avoid problems
+ with libhybris
 
 Change-Id: I498a9749853e6a5a4aaa4ae93479aff083e02d4c
 Signed-off-by: Simonas Leleiva <simonas.leleiva@meramo.co.uk>

--- a/bionic/0005-hybris-Fix-TLS-slots-for-x86-Aligns-with-this-libhyb.patch
+++ b/bionic/0005-hybris-Fix-TLS-slots-for-x86-Aligns-with-this-libhyb.patch
@@ -1,7 +1,7 @@
-From 829c9f20e760085a4c5872f6f1292c8d0e418e57 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ilya Bizyaev <bizyaev@zoho.com>
 Date: Sat, 20 Jan 2018 17:48:27 +0300
-Subject: [PATCH 5/6] (hybris) Fix TLS slots for x86 Aligns with this libhybris
+Subject: [PATCH] (hybris) Fix TLS slots for x86 Aligns with this libhybris
  patch: https://github.com/libhybris/libhybris/pull/370
 
 Change-Id: Ibdbfa1c1672cbac5a687afdedbb1d8ff05861f4f

--- a/bionic/0006-hybris-don-t-fail-because-of-fsetxattr.patch
+++ b/bionic/0006-hybris-don-t-fail-because-of-fsetxattr.patch
@@ -1,7 +1,7 @@
-From f0cc4b60fd962a9f220b3a393558226901f3f83e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <f_haider@gmx.at>
 Date: Thu, 28 Mar 2019 13:10:48 -0400
-Subject: [PATCH 6/6] (hybris) don't fail because of fsetxattr
+Subject: [PATCH] (hybris) don't fail because of fsetxattr
 
 Change-Id: I4d765ff401d6b4f12da0305416cb751eb0c9e96b
 ---

--- a/build/make/0001-hybris-rename-dbus-group-to-adbus-to-avoid-conflicts.patch
+++ b/build/make/0001-hybris-rename-dbus-group-to-adbus-to-avoid-conflicts.patch
@@ -1,8 +1,8 @@
-From 20db53a968e052d3492674fb5fefd8a785405ad4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Thu, 30 Aug 2018 14:42:07 +0200
-Subject: [PATCH 1/3] (hybris) rename dbus group to adbus to avoid conflicts
- with mer.
+Subject: [PATCH] (hybris) rename dbus group to adbus to avoid conflicts with
+ mer.
 
 ---
  tools/fs_config/fs_config_generator.py | 3 ++-

--- a/build/make/0002-hybris-build-minimization-might-be-improveable-but-t.patch
+++ b/build/make/0002-hybris-build-minimization-might-be-improveable-but-t.patch
@@ -1,8 +1,8 @@
-From 1dba61e7803e8f88b8edf58b990f1af8616e61b7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Thu, 7 Jun 2018 15:32:40 +0000
-Subject: [PATCH 2/3] (hybris) build minimization (might be improveable, but
- this version doesn't break dependancies)
+Subject: [PATCH] (hybris) build minimization (might be improveable, but this
+ version doesn't break dependancies)
 
 Change-Id: Ic862dc084f5f4e3fa7ccd90b0757deff0f17b802
 ---

--- a/build/make/0003-hybris-Reduce-vendorimage-build-size.patch
+++ b/build/make/0003-hybris-Reduce-vendorimage-build-size.patch
@@ -1,7 +1,7 @@
-From 406f994725894d4076f84a4210277f40ae43f2cf Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Fri, 22 Mar 2019 18:36:56 +0200
-Subject: [PATCH 3/3] (hybris) Reduce vendorimage build size.
+Subject: [PATCH] (hybris) Reduce vendorimage build size.
 
 Change-Id: Id025a7d7c81cb19c2881ff6619084b638ce983fb
 ---

--- a/frameworks/av/0001-hybris-AudioService-is-disabled-in-hybris-adaptation.patch
+++ b/frameworks/av/0001-hybris-AudioService-is-disabled-in-hybris-adaptation.patch
@@ -1,7 +1,7 @@
-From 3b3570a33ce50318bb4eb6b4f9b4ede9665308b0 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Sun, 30 Oct 2016 14:07:11 +0000
-Subject: [PATCH 1/1] (hybris) AudioService is disabled in hybris adaptations
+Subject: [PATCH] (hybris) AudioService is disabled in hybris adaptations
 
 Without this patch, camera is waiting for AudioService indefinitely
 

--- a/frameworks/native/0001-hybris-Use-mini-services-and-disable-starting-unneed.patch
+++ b/frameworks/native/0001-hybris-Use-mini-services-and-disable-starting-unneed.patch
@@ -1,7 +1,7 @@
-From e58de07caa2c0c08b734a0ffa87bb2e9b8d2c020 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Thu, 13 Jul 2017 00:53:55 +0300
-Subject: [PATCH 1/5] (hybris) Use mini services and disable starting unneeded
+Subject: [PATCH] (hybris) Use mini services and disable starting unneeded
  services.
 
 Change-Id: I6e80eb3e2d92ddfbd83f1933971c3f24e9570d28

--- a/frameworks/native/0002-hybris-Pick-GLES-shared-objects-from-appropriate-pat.patch
+++ b/frameworks/native/0002-hybris-Pick-GLES-shared-objects-from-appropriate-pat.patch
@@ -1,7 +1,7 @@
-From 44eff29a55aed4d115ea468b00d4345ffcdf7a2d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Wed, 15 Jul 2015 08:29:08 +0000
-Subject: [PATCH 2/5] (hybris) Pick GLES shared objects from appropriate paths
+Subject: [PATCH] (hybris) Pick GLES shared objects from appropriate paths
  (32-bit case)
 
 Change-Id: I4c7739ba8a4d64fa115163d5700b0df3370b286b

--- a/frameworks/native/0003-hybris-Use-private-__get_tls_hooks-from-bionic.patch
+++ b/frameworks/native/0003-hybris-Use-private-__get_tls_hooks-from-bionic.patch
@@ -1,7 +1,7 @@
-From bb8d83f75b1b0a7eb2aeb63ef53fd83f750205b2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david.greaves@jollamobile.com>
 Date: Tue, 25 Nov 2014 14:55:27 +0100
-Subject: [PATCH 3/5] (hybris) Use private __get_tls_hooks from bionic
+Subject: [PATCH] (hybris) Use private __get_tls_hooks from bionic
 
 Change-Id: I38a4ea6d8561ab7da5dfedeeba16b84ee493051e
 Signed-off-by: David Greaves <david.greaves@jollamobile.com>

--- a/frameworks/native/0004-hybris-Allow-surfaceflinger-to-be-started-from-Sailf.patch
+++ b/frameworks/native/0004-hybris-Allow-surfaceflinger-to-be-started-from-Sailf.patch
@@ -1,8 +1,7 @@
-From 43efb446b6872bdff454f1a67048e400345704f4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Wed, 18 Apr 2018 19:00:03 +0200
-Subject: [PATCH 4/5] (hybris) Allow surfaceflinger to be started from
- SailfishOS.
+Subject: [PATCH] (hybris) Allow surfaceflinger to be started from SailfishOS.
 
 Change-Id: Ibaecd8d27524bbb0d3bc7b40017bf92736b8629d
 Signed-off-by: Simonas Leleiva <simonas.leleiva@meramo.co.uk>

--- a/frameworks/native/0005-hybris-Create-the-somehow-missing-settingsd-socket-f.patch
+++ b/frameworks/native/0005-hybris-Create-the-somehow-missing-settingsd-socket-f.patch
@@ -1,8 +1,8 @@
-From 36bf4036b08f84e9756346c9c278ff87f191cc99 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Sun, 16 Jun 2019 13:14:30 +0200
-Subject: [PATCH 5/5] (hybris) Create the (somehow) missing settingsd socket
- for rild
+Subject: [PATCH] (hybris) Create the (somehow) missing settingsd socket for
+ rild
 
 Change-Id: Ic7415aab65788f37ee5c5a67be1916319e484f77
 ---

--- a/hardware/libhardware/0001-hybris-Add-aapcs-float-handling-to-audio-api-headers.patch
+++ b/hardware/libhardware/0001-hybris-Add-aapcs-float-handling-to-audio-api-headers.patch
@@ -1,7 +1,7 @@
-From d6d20d56e45a3799c9edf386b73b0a450c2b20f0 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Siteshwar Vashisht <siteshwar@gmail.com>
 Date: Wed, 21 May 2014 01:23:45 +0530
-Subject: [PATCH 1/3] (hybris) Add aapcs float handling to audio api headers
+Subject: [PATCH] (hybris) Add aapcs float handling to audio api headers
 
 Change-Id: I2b0015aa75e1afa849a5563fa92d041c37f88780
 ---

--- a/hardware/libhardware/0002-hybris-Search-for-libraries-first-from-usr-libexec-d.patch
+++ b/hardware/libhardware/0002-hybris-Search-for-libraries-first-from-usr-libexec-d.patch
@@ -1,7 +1,7 @@
-From c4497049d7c4e5fc9084aec50469137c8bc8ef9f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Matti Lehtimaki <matti.lehtimaki@gmail.com>
 Date: Wed, 5 Aug 2015 14:31:01 +0200
-Subject: [PATCH 2/3] (hybris) Search for libraries first from
+Subject: [PATCH] (hybris) Search for libraries first from
  /usr/libexec/droid-hybris/system/lib/hw/.
 
 Change-Id: I7496d961f8218b6077b9d628dd350ac20550b5d2

--- a/hardware/libhardware/0003-hybris-gps.h-Use-proper-aapcs-attribute-with-functio.patch
+++ b/hardware/libhardware/0003-hybris-gps.h-Use-proper-aapcs-attribute-with-functio.patch
@@ -1,8 +1,8 @@
-From 05c96a503f8559cb86bd82a0dce8bc6c55a02ea8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jollamobile.com>
 Date: Tue, 30 Jan 2018 14:55:33 +0200
-Subject: [PATCH 3/3] (hybris) gps.h Use proper aapcs attribute with functions
- with float arguments
+Subject: [PATCH] (hybris) gps.h Use proper aapcs attribute with functions with
+ float arguments
 
 ---
  include/hardware/gps.h | 10 ++++++++--

--- a/system/core/0001-hybris-Add-usr-libexec-droid-hybris-lib-dev-alog-to-.patch
+++ b/system/core/0001-hybris-Add-usr-libexec-droid-hybris-lib-dev-alog-to-.patch
@@ -1,9 +1,8 @@
-From 6b49a219e0febdab4bf42362dbf64075c08c1190 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 6 Nov 2013 21:09:30 +0000
-Subject: [PATCH 01/41] (hybris) Add /usr/libexec/droid-hybris/lib-dev-alog/ to
- the LD_LIBRARY_PATH for all init'ed binaries to support the /dev/alog used in
- Mer
+Subject: [PATCH] (hybris) Add /usr/libexec/droid-hybris/lib-dev-alog/ to the
+ LD_LIBRARY_PATH for all init'ed binaries to support the /dev/alog used in Mer
 
 Change-Id: If58b8bd7c52b71e6e1f86f714142890dc8c73fd8
 ---
@@ -11,7 +10,7 @@ Change-Id: If58b8bd7c52b71e6e1f86f714142890dc8c73fd8
  1 file changed, 4 insertions(+)
 
 diff --git a/rootdir/init.environ.rc.in b/rootdir/init.environ.rc.in
-index 2e2ab7465..deefac4e0 100644
+index 2e2ab74..deefac4 100644
 --- a/rootdir/init.environ.rc.in
 +++ b/rootdir/init.environ.rc.in
 @@ -1,5 +1,9 @@
@@ -25,5 +24,5 @@ index 2e2ab7465..deefac4e0 100644
      export ANDROID_ROOT /system
      export ANDROID_ASSETS /system/app
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0002-hybris-Don-t-create-mount-dev-proc-sys.-when-booting.patch
+++ b/system/core/0002-hybris-Don-t-create-mount-dev-proc-sys.-when-booting.patch
@@ -1,8 +1,8 @@
-From 914e4a3ad0b1208a7fa987c254da80e98fa1ab15 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 8 Oct 2013 16:59:30 +0100
-Subject: [PATCH 02/41] (hybris) Don't create/mount dev/proc/sys... when
- booting with Mer
+Subject: [PATCH] (hybris) Don't create/mount dev/proc/sys... when booting with
+ Mer
 
 Change-Id: I16afd5bf56ee3e36f09b3496b80e356ce9269a64
 ---
@@ -10,7 +10,7 @@ Change-Id: I16afd5bf56ee3e36f09b3496b80e356ce9269a64
  1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index fc58eeabb..527d275c7 100644
+index fc58eea..527d275 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
 @@ -574,17 +574,17 @@ int main(int argc, char** argv) {
@@ -37,5 +37,5 @@ index fc58eeabb..527d275c7 100644
  
          mknod("/dev/kmsg", S_IFCHR | 0600, makedev(1, 11));
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0003-hybris-Mer-can-specify-mis-alignment-handling-this-i.patch
+++ b/system/core/0003-hybris-Mer-can-specify-mis-alignment-handling-this-i.patch
@@ -1,8 +1,8 @@
-From 3344dd4efec1082070a1b88f6943b051dd5b9a0d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:07:56 +0100
-Subject: [PATCH 03/41] (hybris) Mer can specify mis-alignment handling - this
- is the wrong place to set it
+Subject: [PATCH] (hybris) Mer can specify mis-alignment handling - this is the
+ wrong place to set it
 
 Change-Id: Ib46c0a0b6d285dbcd05736e7ba9e9fd0a0480984
 ---
@@ -10,7 +10,7 @@ Change-Id: Ib46c0a0b6d285dbcd05736e7ba9e9fd0a0480984
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index f4b208278..6e7d9868d 100644
+index f4b2082..6e7d986 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -109,13 +109,15 @@ on init
@@ -31,5 +31,5 @@ index f4b208278..6e7d9868d 100644
      write /proc/sys/kernel/sched_wakeup_granularity_ns 2000000
      write /proc/sys/kernel/sched_child_runs_first 0
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0004-hybris-Mount-points-are-handled-by-Mer.patch
+++ b/system/core/0004-hybris-Mount-points-are-handled-by-Mer.patch
@@ -1,7 +1,7 @@
-From f78562952e21ff13b1d8799245b94875e80b5e62 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:09:20 +0100
-Subject: [PATCH 04/41] (hybris) Mount points are handled by Mer
+Subject: [PATCH] (hybris) Mount points are handled by Mer
 
 Change-Id: I295b30a47b6e147b037275032a00b304085fe711
 ---
@@ -9,7 +9,7 @@ Change-Id: I295b30a47b6e147b037275032a00b304085fe711
  1 file changed, 8 insertions(+), 6 deletions(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 6e7d9868d..3ab075723 100644
+index 6e7d986..3ab0757 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -45,8 +45,10 @@ on init
@@ -43,5 +43,5 @@ index 6e7d9868d..3ab075723 100644
      # Make sure /sys/kernel/debug (if present) is labeled properly
      # Note that tracefs may be mounted under debug, so we need to cross filesystems
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0005-hybris-Systemd-handles-control-groups.patch
+++ b/system/core/0005-hybris-Systemd-handles-control-groups.patch
@@ -1,7 +1,7 @@
-From 7da4a8e3d9835ca4aaaa5e83019660d286f0b67f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:10:16 +0100
-Subject: [PATCH 05/41] (hybris) Systemd handles control groups
+Subject: [PATCH] (hybris) Systemd handles control groups
 
 Change-Id: I92ef4b2389544906be32169c57176575eb1719ec
 ---
@@ -9,7 +9,7 @@ Change-Id: I92ef4b2389544906be32169c57176575eb1719ec
  1 file changed, 8 deletions(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 3ab075723..26118970e 100644
+index 3ab0757..2611897 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -28,14 +28,6 @@ on early-init
@@ -28,5 +28,5 @@ index 3ab075723..26118970e 100644
  
  on init
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0006-hybris-Mer-uses-udev.patch
+++ b/system/core/0006-hybris-Mer-uses-udev.patch
@@ -1,7 +1,7 @@
-From ff4d149d06a9b50c3cbebf811dc2fa6748c6e547 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:12:18 +0100
-Subject: [PATCH 06/41] (hybris) Mer uses udev
+Subject: [PATCH] (hybris) Mer uses udev
 
 Change-Id: I7588a80db2c77879fb56d5decfd055224f20ab54
 ---
@@ -9,7 +9,7 @@ Change-Id: I7588a80db2c77879fb56d5decfd055224f20ab54
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 26118970e..baba9cc6d 100644
+index 2611897..baba9cc 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -28,7 +28,7 @@ on early-init
@@ -22,5 +22,5 @@ index 26118970e..baba9cc6d 100644
  on init
      sysclktz 0
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0007-hybris-Add-a-ready-trigger-to-init-to-run-post-boot.patch
+++ b/system/core/0007-hybris-Add-a-ready-trigger-to-init-to-run-post-boot.patch
@@ -1,7 +1,7 @@
-From 0a01c357e95aca60229d8c7c40c11de42d44f5ae Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 20 Nov 2013 19:18:51 +0000
-Subject: [PATCH 07/41] (hybris) Add a ready trigger to init to run post boot
+Subject: [PATCH] (hybris) Add a ready trigger to init to run post boot
 
 Change-Id: I9c828463424c0e82c3de0159db08299e7ce6fe06
 ---
@@ -9,7 +9,7 @@ Change-Id: I9c828463424c0e82c3de0159db08299e7ce6fe06
  1 file changed, 6 insertions(+)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index 527d275c7..9a451877a 100644
+index 527d275..9a45187 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
 @@ -750,6 +750,12 @@ int main(int argc, char** argv) {
@@ -26,5 +26,5 @@ index 527d275c7..9a451877a 100644
          // By default, sleep until something happens.
          int epoll_timeout_ms = -1;
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0008-hybris-Notify-Mer-s-systemd-that-we-re-done.patch
+++ b/system/core/0008-hybris-Notify-Mer-s-systemd-that-we-re-done.patch
@@ -1,7 +1,7 @@
-From 89879a92b37666f69dfb4a8f41037ff07b2ca6a3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 20 Nov 2013 19:24:31 +0000
-Subject: [PATCH 08/41] (hybris) Notify Mer's systemd that we're done
+Subject: [PATCH] (hybris) Notify Mer's systemd that we're done
 
 Change-Id: If6a16f43397f00c8e579af79ae6cf8459786e7b3
 Signed-off-by: David Greaves <david.greaves@jollamobile.com>
@@ -10,7 +10,7 @@ Signed-off-by: David Greaves <david.greaves@jollamobile.com>
  1 file changed, 16 insertions(+)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index baba9cc6d..74389e016 100644
+index baba9cc..74389e0 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -757,3 +757,19 @@ on property:ro.debuggable=1
@@ -34,5 +34,5 @@ index baba9cc6d..74389e016 100644
 +    start flash_recovery
 +
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0009-hybris-Disable-usb-import.patch
+++ b/system/core/0009-hybris-Disable-usb-import.patch
@@ -1,7 +1,7 @@
-From 9dc0521751b7ae08cb41275f55883279989c8332 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 19 Feb 2014 19:02:32 +0000
-Subject: [PATCH 09/41] (hybris) Disable usb import
+Subject: [PATCH] (hybris) Disable usb import
 
 Change-Id: I8aba60bc79fb4aab3854f0569b325ad69c5126d4
 Signed-off-by: David Greaves <david@dgreaves.com>
@@ -10,7 +10,7 @@ Signed-off-by: David Greaves <david@dgreaves.com>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 74389e016..ba2e2251c 100644
+index 74389e0..ba2e225 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -5,7 +5,8 @@
@@ -24,5 +24,5 @@ index 74389e016..ba2e2251c 100644
  import /vendor/etc/init/hw/init.${ro.hardware}.rc
  import /init.usb.configfs.rc
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0010-hybris-allow-system-group-to-trigger-haptics.patch
+++ b/system/core/0010-hybris-allow-system-group-to-trigger-haptics.patch
@@ -1,7 +1,7 @@
-From 25079bedd569a97632a4872d9baa49b984b42c33 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Thu, 13 Mar 2014 08:51:53 +0000
-Subject: [PATCH 10/41] (hybris) allow system group to trigger haptics
+Subject: [PATCH] (hybris) allow system group to trigger haptics
 
 Signed-off-by: Simonas Leleiva <simonas.leleiva@jollamobile.com>
 
@@ -14,7 +14,7 @@ Change-Id: I9f1af094fa8a4ef48f4c3ea0ec35cb66d3c083d8
  1 file changed, 3 insertions(+)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index ba2e2251c..8ef4d075d 100644
+index ba2e225..8ef4d07 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -667,6 +667,9 @@ on boot
@@ -28,5 +28,5 @@ index ba2e2251c..8ef4d075d 100644
      class_start hal
  
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0011-hybris-trigger-late_start-on-property-change.patch
+++ b/system/core/0011-hybris-trigger-late_start-on-property-change.patch
@@ -1,7 +1,7 @@
-From 658a8737fc0acdb257603c0350c4bbdc5c30e902 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Tue, 18 Mar 2014 14:07:11 +0000
-Subject: [PATCH 11/41] (hybris) trigger late_start on property change
+Subject: [PATCH] (hybris) trigger late_start on property change
 
 Android's late_start is triggered by mount_all, which also determines whether
 the /data partition is encrypted.
@@ -20,7 +20,7 @@ Conflicts:
  1 file changed, 5 insertions(+)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 8ef4d075d..5520adfb4 100644
+index 8ef4d07..5520adf 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -675,6 +675,7 @@ on boot
@@ -43,5 +43,5 @@ index 8ef4d075d..5520adfb4 100644
      class_start charger
  
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0012-hybris-property_service.c-adding-support-for-getprop.patch
+++ b/system/core/0012-hybris-property_service.c-adding-support-for-getprop.patch
@@ -1,8 +1,8 @@
-From 92f07fc5f32696e9c1b5d327207525de06f70118 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
 Date: Thu, 31 Oct 2013 12:19:19 +0200
-Subject: [PATCH 12/41] (hybris) property_service.c: adding support for getprop
- and listprop
+Subject: [PATCH] (hybris) property_service.c: adding support for getprop and
+ listprop
 
 Change-Id: Ie5fbdb55c48038ce8250f27500623b3b81cc5cd1
 Signed-off-by: Jani Monoses <jani@ubuntu.com>
@@ -19,7 +19,7 @@ Conflicts:
  2 files changed, 38 insertions(+), 1 deletion(-)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index 9a451877a..49f646797 100644
+index 9a45187..49f6467 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
 @@ -699,6 +699,7 @@ int main(int argc, char** argv) {
@@ -40,7 +40,7 @@ index 9a451877a..49f646797 100644
      /* Run actions when all boot up is done and init is ready */
      am.QueueEventTrigger("ready");
 diff --git a/init/property_service.cpp b/init/property_service.cpp
-index 4172ba754..f0975313b 100644
+index 4172ba7..f097531 100644
 --- a/init/property_service.cpp
 +++ b/init/property_service.cpp
 @@ -481,6 +481,9 @@ uint32_t HandlePropertySet(const std::string& name, const std::string& value,
@@ -95,5 +95,5 @@ index 4172ba754..f0975313b 100644
          LOG(ERROR) << "sys_prop: invalid command " << cmd;
          socket.SendUint32(PROP_ERROR_INVALID_CMD);
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0013-hybris-reach-main-init-state.patch
+++ b/system/core/0013-hybris-reach-main-init-state.patch
@@ -1,7 +1,7 @@
-From 5209d32be26139274a72a5de571cda056740cf77 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Sat, 22 Aug 2015 12:03:42 +0100
-Subject: [PATCH 13/41] (hybris) reach main init state
+Subject: [PATCH] (hybris) reach main init state
 
 Change-Id: I471f48afaebf91c92f0d2a7bd3a24c5d1fa58ecd
 ---
@@ -9,7 +9,7 @@ Change-Id: I471f48afaebf91c92f0d2a7bd3a24c5d1fa58ecd
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 5520adfb4..9bbca6c1b 100644
+index 5520adf..9bbca6c 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -390,7 +390,9 @@ on post-fs-data
@@ -24,5 +24,5 @@ index 5520adfb4..9bbca6c1b 100644
  
      # Start bootcharting as soon as possible after the data partition is
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0014-hybris-Disable-setting-hostname-and-domainname-in-in.patch
+++ b/system/core/0014-hybris-Disable-setting-hostname-and-domainname-in-in.patch
@@ -1,8 +1,7 @@
-From 7f2a812cdfe54d764fa120176013fff799412b41 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Sat, 6 Aug 2016 11:37:38 +0300
-Subject: [PATCH 14/41] (hybris) Disable setting hostname and domainname in
- init.rc.
+Subject: [PATCH] (hybris) Disable setting hostname and domainname in init.rc.
 
 Change-Id: I5b9f59e80760e53636763c89f8f76f350c17b3ec
 ---
@@ -10,7 +9,7 @@ Change-Id: I5b9f59e80760e53636763c89f8f76f350c17b3ec
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 9bbca6c1b..55dcd8782 100644
+index 9bbca6c..55dcd87 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -578,8 +578,9 @@ on zygote-start && property:ro.crypto.state=encrypted && property:ro.crypto.type
@@ -26,5 +25,5 @@ index 9bbca6c1b..55dcd8782 100644
      # IPsec SA default expiration length
      write /proc/sys/net/core/xfrm_acq_expires 3600
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0015-hybris-Update-rootdir-for-64bit-libs.patch
+++ b/system/core/0015-hybris-Update-rootdir-for-64bit-libs.patch
@@ -1,7 +1,7 @@
-From 28e6cf402b4e671a008b4cba864c266a4da8e39d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Martin Ghosal <Martin.Ghosal@sky.uk>
 Date: Sat, 15 Oct 2016 15:38:47 +0100
-Subject: [PATCH 15/41] (hybris) Update rootdir for 64bit libs
+Subject: [PATCH] (hybris) Update rootdir for 64bit libs
 
 Change-Id: I593ae40da755c116bb28c96dcace863e6b30b4cc
 ---
@@ -9,7 +9,7 @@ Change-Id: I593ae40da755c116bb28c96dcace863e6b30b4cc
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.environ.rc.in b/rootdir/init.environ.rc.in
-index deefac4e0..144f3d396 100644
+index deefac4..144f3d3 100644
 --- a/rootdir/init.environ.rc.in
 +++ b/rootdir/init.environ.rc.in
 @@ -3,7 +3,8 @@ on init
@@ -23,5 +23,5 @@ index deefac4e0..144f3d396 100644
      export ANDROID_ROOT /system
      export ANDROID_ASSETS /system/app
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0016-hybris-Disable-all-zygote-variations.patch
+++ b/system/core/0016-hybris-Disable-all-zygote-variations.patch
@@ -1,7 +1,7 @@
-From 4d6294e08a0d838dd9078e0ba65e6177631ed111 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Martin Ghosal <Martin.Ghosal@sky.uk>
 Date: Sun, 8 Jan 2017 16:34:54 +0000
-Subject: [PATCH 16/41] (hybris) Disable all zygote variations
+Subject: [PATCH] (hybris) Disable all zygote variations
 
 Change-Id: Ie1ad26486f47b3bf67134db917b3c9e51536904c
 ---
@@ -12,7 +12,7 @@ Change-Id: Ie1ad26486f47b3bf67134db917b3c9e51536904c
  4 files changed, 6 insertions(+)
 
 diff --git a/rootdir/init.zygote32.rc b/rootdir/init.zygote32.rc
-index ac87979ec..b24f7b5b9 100644
+index ac87979..b24f7b5 100644
 --- a/rootdir/init.zygote32.rc
 +++ b/rootdir/init.zygote32.rc
 @@ -12,3 +12,4 @@ service zygote /system/bin/app_process -Xzygote /system/bin --zygote --start-sys
@@ -21,7 +21,7 @@ index ac87979ec..b24f7b5b9 100644
      writepid /dev/cpuset/foreground/tasks
 +    disabled
 diff --git a/rootdir/init.zygote32_64.rc b/rootdir/init.zygote32_64.rc
-index a535846de..62b92363c 100644
+index a535846..62b9236 100644
 --- a/rootdir/init.zygote32_64.rc
 +++ b/rootdir/init.zygote32_64.rc
 @@ -12,6 +12,7 @@ service zygote /system/bin/app_process32 -Xzygote /system/bin --zygote --start-s
@@ -38,7 +38,7 @@ index a535846de..62b92363c 100644
      writepid /dev/cpuset/foreground/tasks
 +    disabled
 diff --git a/rootdir/init.zygote64.rc b/rootdir/init.zygote64.rc
-index 6fc810bfa..edf82ce4b 100644
+index 6fc810b..edf82ce 100644
 --- a/rootdir/init.zygote64.rc
 +++ b/rootdir/init.zygote64.rc
 @@ -12,3 +12,4 @@ service zygote /system/bin/app_process64 -Xzygote /system/bin --zygote --start-s
@@ -47,7 +47,7 @@ index 6fc810bfa..edf82ce4b 100644
      writepid /dev/cpuset/foreground/tasks
 +    disabled
 diff --git a/rootdir/init.zygote64_32.rc b/rootdir/init.zygote64_32.rc
-index 7ddd52ee5..e74202a7e 100644
+index 7ddd52e..e74202a 100644
 --- a/rootdir/init.zygote64_32.rc
 +++ b/rootdir/init.zygote64_32.rc
 @@ -12,6 +12,7 @@ service zygote /system/bin/app_process64 -Xzygote /system/bin --zygote --start-s
@@ -64,5 +64,5 @@ index 7ddd52ee5..e74202a7e 100644
      writepid /dev/cpuset/foreground/tasks
 +    disabled
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0017-hybris-Disable-ueventd-service.patch
+++ b/system/core/0017-hybris-Disable-ueventd-service.patch
@@ -1,7 +1,7 @@
-From 028e980eb3a8c45348d6fb7b8b40bb70d7a9be62 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Martin Ghosal <Martin.Ghosal@sky.uk>
 Date: Sun, 8 Jan 2017 17:16:08 +0000
-Subject: [PATCH 17/41] (hybris) Disable ueventd service
+Subject: [PATCH] (hybris) Disable ueventd service
 
 Change-Id: I8ee7b863a533f4a6ef7658ef1c1ef4bdb95d5d65
 ---
@@ -9,7 +9,7 @@ Change-Id: I8ee7b863a533f4a6ef7658ef1c1ef4bdb95d5d65
  1 file changed, 2 insertions(+)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 55dcd8782..5231f45fd 100644
+index 55dcd87..5231f45 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -748,6 +748,8 @@ service ueventd /sbin/ueventd
@@ -22,5 +22,5 @@ index 55dcd8782..5231f45fd 100644
  service console /system/bin/sh
      class core
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0018-hybris-Disable-SELinux.patch
+++ b/system/core/0018-hybris-Disable-SELinux.patch
@@ -1,7 +1,7 @@
-From 414f713a6b29ba3d509f797a34792b781a243e31 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Thu, 9 Feb 2017 21:48:19 +0200
-Subject: [PATCH 18/41] (hybris) Disable SELinux
+Subject: [PATCH] (hybris) Disable SELinux
 
 Change-Id: I0511b2a0de1b20996f4fb8e9f3569acb41e2cf0f
 ---
@@ -11,7 +11,7 @@ Change-Id: I0511b2a0de1b20996f4fb8e9f3569acb41e2cf0f
  3 files changed, 14 insertions(+), 1 deletion(-)
 
 diff --git a/init/property_service.cpp b/init/property_service.cpp
-index f0975313b..3333eedb1 100644
+index f097531..3333eed 100644
 --- a/init/property_service.cpp
 +++ b/init/property_service.cpp
 @@ -112,6 +112,8 @@ void property_init() {
@@ -24,7 +24,7 @@ index f0975313b..3333eedb1 100644
          return false;
      }
 diff --git a/init/selinux.cpp b/init/selinux.cpp
-index 0ba5c4ae3..416c12789 100644
+index 0ba5c4a..416c127 100644
 --- a/init/selinux.cpp
 +++ b/init/selinux.cpp
 @@ -382,6 +382,9 @@ bool LoadPolicy() {
@@ -38,7 +38,7 @@ index 0ba5c4ae3..416c12789 100644
  
      LOG(INFO) << "Loading SELinux policy";
 diff --git a/init/service.cpp b/init/service.cpp
-index 37d3a8807..9c294af15 100644
+index 37d3a88..9c294af 100644
 --- a/init/service.cpp
 +++ b/init/service.cpp
 @@ -66,6 +66,8 @@ using android::base::WriteStringToFile;
@@ -92,5 +92,5 @@ index 37d3a8807..9c294af15 100644
  
      pid_t pid = -1;
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0019-hybris-Properly-handle-shutdown-from-Mer.patch
+++ b/system/core/0019-hybris-Properly-handle-shutdown-from-Mer.patch
@@ -1,7 +1,7 @@
-From 2f367d901e5873529f52d0040d95de043d1e57cb Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Sat, 8 Jul 2017 00:27:20 +0300
-Subject: [PATCH 19/41] (hybris) Properly handle shutdown from Mer.
+Subject: [PATCH] (hybris) Properly handle shutdown from Mer.
 
 Change-Id: I89daebb9559d38f3c639f4634c417252c7a92fe0
 ---
@@ -9,7 +9,7 @@ Change-Id: I89daebb9559d38f3c639f4634c417252c7a92fe0
  1 file changed, 9 insertions(+)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 5231f45fd..d3ef1148d 100644
+index 5231f45..d3ef114 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -783,6 +783,15 @@ service droid_init_done /bin/sh /usr/bin/droid/droid-init-done.sh
@@ -29,5 +29,5 @@ index 5231f45fd..d3ef1148d 100644
  on property:persist.sys.recovery_update=true
      start flash_recovery
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0020-hybris-Use-services-from-usr-libexec-droid-hybris-sy.patch
+++ b/system/core/0020-hybris-Use-services-from-usr-libexec-droid-hybris-sy.patch
@@ -1,19 +1,19 @@
-From 248324f535acf40cb7f0379f0dcf81a5048d8078 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Thu, 9 Feb 2017 21:57:47 +0200
-Subject: [PATCH 20/41] (hybris) Use services from
+Subject: [PATCH] (hybris) Use services from
  /usr/libexec/droid-hybris/system/etc/init/.
 
 Change-Id: I6185781c2bd6a2db281201ad705394f4d6d24131
 ---
  init/init.cpp        |   4 +-
- init/init_parser.cpp | 169 +++++++++++++++++++++++++++++++++++++++++++
+ init/init_parser.cpp | 169 +++++++++++++++++++++++++++++++++++++++++++++++++++
  init/util.cpp        |   3 +-
  3 files changed, 173 insertions(+), 3 deletions(-)
  create mode 100644 init/init_parser.cpp
 
 diff --git a/init/init.cpp b/init/init.cpp
-index 49f646797..8dc013d3e 100644
+index 49f6467..8dc013d 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
 @@ -114,8 +114,8 @@ static void LoadBootScripts(ActionManager& action_manager, ServiceList& service_
@@ -29,7 +29,7 @@ index 49f646797..8dc013d3e 100644
              late_import_paths.emplace_back("/product/etc/init");
 diff --git a/init/init_parser.cpp b/init/init_parser.cpp
 new file mode 100644
-index 000000000..c4b80636a
+index 0000000..c4b8063
 --- /dev/null
 +++ b/init/init_parser.cpp
 @@ -0,0 +1,169 @@
@@ -203,7 +203,7 @@ index 000000000..c4b80636a
 +}  // namespace init
 +}  // namespace android
 diff --git a/init/util.cpp b/init/util.cpp
-index 4455b2eb1..8eb184da9 100644
+index 4455b2e..8eb184d 100644
 --- a/init/util.cpp
 +++ b/init/util.cpp
 @@ -162,7 +162,8 @@ out_unlink:
@@ -217,5 +217,5 @@ index 4455b2eb1..8eb184da9 100644
          return ErrnoError() << "open() failed";
      }
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0021-hybris-Remove-LD_LIBRARY_PATH-from-init.environ.rc.patch
+++ b/system/core/0021-hybris-Remove-LD_LIBRARY_PATH-from-init.environ.rc.patch
@@ -1,7 +1,7 @@
-From 396c056ef7dc0e05d4161597dcee5d8987f2aba8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Tue, 17 Oct 2017 21:58:40 +0300
-Subject: [PATCH 21/41] (hybris) Remove LD_LIBRARY_PATH from init.environ.rc
+Subject: [PATCH] (hybris) Remove LD_LIBRARY_PATH from init.environ.rc
 
 Change-Id: I52a2c733f609f90b6ac31be72a4f8fe7681beac0
 ---
@@ -9,7 +9,7 @@ Change-Id: I52a2c733f609f90b6ac31be72a4f8fe7681beac0
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.environ.rc.in b/rootdir/init.environ.rc.in
-index 144f3d396..fcafbb113 100644
+index 144f3d3..fcafbb1 100644
 --- a/rootdir/init.environ.rc.in
 +++ b/rootdir/init.environ.rc.in
 @@ -4,7 +4,8 @@ on init
@@ -23,5 +23,5 @@ index 144f3d396..fcafbb113 100644
      export ANDROID_ROOT /system
      export ANDROID_ASSETS /system/app
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0022-hybris-define-32-bit-LD_LIBRARY_PATH-for-32-bit-devi.patch
+++ b/system/core/0022-hybris-define-32-bit-LD_LIBRARY_PATH-for-32-bit-devi.patch
@@ -1,8 +1,7 @@
-From fca8d01fbc6ea3c755df19b79780eba169ca8823 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jollamobile.com>
 Date: Wed, 25 Oct 2017 14:14:59 +0300
-Subject: [PATCH 22/41] (hybris) define 32-bit LD_LIBRARY_PATH for 32-bit
- devices
+Subject: [PATCH] (hybris) define 32-bit LD_LIBRARY_PATH for 32-bit devices
 
 ---
  rootdir/Android.mk                   | 12 ++++++++++++
@@ -13,7 +12,7 @@ Subject: [PATCH 22/41] (hybris) define 32-bit LD_LIBRARY_PATH for 32-bit
  create mode 100644 rootdir/init.extraenv.armeabi-v7a.rc
 
 diff --git a/rootdir/Android.mk b/rootdir/Android.mk
-index 5f5c363a7..af5e68d3a 100644
+index 5f5c363..af5e68d 100644
 --- a/rootdir/Android.mk
 +++ b/rootdir/Android.mk
 @@ -8,6 +8,18 @@ LOCAL_MODULE := init.rc
@@ -36,7 +35,7 @@ index 5f5c363a7..af5e68d3a 100644
  include $(BUILD_PREBUILT)
  
 diff --git a/rootdir/init.environ.rc.in b/rootdir/init.environ.rc.in
-index fcafbb113..516dc82f6 100644
+index fcafbb1..516dc82 100644
 --- a/rootdir/init.environ.rc.in
 +++ b/rootdir/init.environ.rc.in
 @@ -5,6 +5,7 @@ on init
@@ -49,14 +48,14 @@ index fcafbb113..516dc82f6 100644
      export ANDROID_ROOT /system
 diff --git a/rootdir/init.extraenv.armeabi-v7a.rc b/rootdir/init.extraenv.armeabi-v7a.rc
 new file mode 100644
-index 000000000..c96e2c65d
+index 0000000..c96e2c6
 --- /dev/null
 +++ b/rootdir/init.extraenv.armeabi-v7a.rc
 @@ -0,0 +1,2 @@
 +on init
 +    export LD_LIBRARY_PATH /usr/libexec/droid-hybris/lib-dev-alog:/vendor/lib:/system/lib
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index d3ef1148d..ec55903bb 100644
+index d3ef114..ec55903 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -4,6 +4,11 @@
@@ -72,5 +71,5 @@ index d3ef1148d..ec55903bb 100644
  # Mer handles usb stuff
  #import /init.usb.rc
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0023-hybris-Fix-list-and-get-properties.patch
+++ b/system/core/0023-hybris-Fix-list-and-get-properties.patch
@@ -1,7 +1,7 @@
-From fb81da3648c836bb76543403f2558290d1057052 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Tue, 16 Jan 2018 16:18:31 +0200
-Subject: [PATCH 23/41] (hybris) Fix list and get properties.
+Subject: [PATCH] (hybris) Fix list and get properties.
 
 Change-Id: I9deb65f147e941fc5c9f91793f851440d02260e1
 ---
@@ -9,7 +9,7 @@ Change-Id: I9deb65f147e941fc5c9f91793f851440d02260e1
  1 file changed, 30 insertions(+), 5 deletions(-)
 
 diff --git a/init/property_service.cpp b/init/property_service.cpp
-index 3333eedb1..5bead058c 100644
+index 3333eed..5bead05 100644
 --- a/init/property_service.cpp
 +++ b/init/property_service.cpp
 @@ -269,6 +269,13 @@ uint32_t InitPropertySet(const std::string& name, const std::string& value) {
@@ -88,5 +88,5 @@ index 3333eedb1..5bead058c 100644
          break;
        }
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0024-hybris-more-SELinux-disablement.patch
+++ b/system/core/0024-hybris-more-SELinux-disablement.patch
@@ -1,7 +1,7 @@
-From 87fe03c9be64114ec272027d1ca12db642e820f0 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Wed, 18 Apr 2018 18:49:02 +0200
-Subject: [PATCH 24/41] (hybris) more SELinux disablement
+Subject: [PATCH] (hybris) more SELinux disablement
 
 Change-Id: Ic1bc474e993f2b66ab9114e88d7ec4f718a99d5c
 Signed-off-by: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
@@ -11,7 +11,7 @@ Signed-off-by: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
  2 files changed, 6 insertions(+)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index 8dc013d3e..e397c4c58 100644
+index 8dc013d..e397c4c 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
 @@ -669,7 +669,10 @@ int main(int argc, char** argv) {
@@ -26,7 +26,7 @@ index 8dc013d3e..e397c4c58 100644
      // Set libavb version for Framework-only OTA match in Treble build.
      const char* avb_version = getenv("INIT_AVB_VERSION");
 diff --git a/init/log.cpp b/init/log.cpp
-index 6198fc25f..0c7c7b50d 100644
+index 6198fc2..0c7c7b5 100644
 --- a/init/log.cpp
 +++ b/init/log.cpp
 @@ -54,6 +54,8 @@ static void InitAborter(const char* abort_message) {
@@ -47,5 +47,5 @@ index 6198fc25f..0c7c7b50d 100644
      android::base::InitLogging(argv, &android::base::KernelLogger, InitAborter);
  }
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0025-hybris-don-t-try-to-mount-since-mer-handles-this.patch
+++ b/system/core/0025-hybris-don-t-try-to-mount-since-mer-handles-this.patch
@@ -1,7 +1,7 @@
-From 9d04e908c83303f72ae0dacec066484fb949f56a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 4 Jun 2018 10:00:13 +0200
-Subject: [PATCH 25/41] (hybris) don't try to mount since mer handles this
+Subject: [PATCH] (hybris) don't try to mount since mer handles this
 
 Change-Id: I305ac649fd199ef11a8d88d350f1fc06171bc0ba
 ---
@@ -9,7 +9,7 @@ Change-Id: I305ac649fd199ef11a8d88d350f1fc06171bc0ba
  1 file changed, 3 insertions(+)
 
 diff --git a/init/init_first_stage.cpp b/init/init_first_stage.cpp
-index 033ce419a..5c9aa9306 100644
+index 033ce41..5c9aa93 100644
 --- a/init/init_first_stage.cpp
 +++ b/init/init_first_stage.cpp
 @@ -477,6 +477,7 @@ bool FirstStageMountVBootV2::InitAvbHandle() {
@@ -30,5 +30,5 @@ index 033ce419a..5c9aa9306 100644
  
  void SetInitAvbVersionInRecovery() {
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0026-hybris-avoid-attempting-to-mount-partitions-mer-syst.patch
+++ b/system/core/0026-hybris-avoid-attempting-to-mount-partitions-mer-syst.patch
@@ -1,8 +1,8 @@
-From 164040621dc4486715572828e165f5dbc3d819c0 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:28:27 +0200
-Subject: [PATCH 26/41] (hybris) avoid attempting to mount partitions,
- mer/systemd handles this
+Subject: [PATCH] (hybris) avoid attempting to mount partitions, mer/systemd
+ handles this
 
 Even partitions weren't mounted by this previously it still would produce an
 error and further boot.
@@ -13,7 +13,7 @@ Change-Id: Icaea2cd8d145d8205f4a130119aedbd2720c868d
  1 file changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/init/builtins.cpp b/init/builtins.cpp
-index 8bd92ccdd..8bb7b0f0c 100644
+index 8bd92cc..8bb7b0f 100644
 --- a/init/builtins.cpp
 +++ b/init/builtins.cpp
 @@ -416,6 +416,7 @@ static void import_late(const std::vector<std::string>& args, size_t start_index
@@ -66,5 +66,5 @@ index 8bd92ccdd..8bb7b0f0c 100644
          /* queue_fs_event will queue event based on mount_fstab return code
           * and return processed return code*/
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0027-hybris-load-services-from-droid-hybris-as-early-as-p.patch
+++ b/system/core/0027-hybris-load-services-from-droid-hybris-as-early-as-p.patch
@@ -1,8 +1,7 @@
-From 8cbe08a2e1525e0c3d203cdbbf97f3ffa0aeb28c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:30:01 +0200
-Subject: [PATCH 27/41] (hybris) load services from droid-hybris as early as
- possible
+Subject: [PATCH] (hybris) load services from droid-hybris as early as possible
 
 This makes sure our service definitions are loaded first and can be used to
 overwrite service definitions which are slightly different to what we need and
@@ -14,7 +13,7 @@ Change-Id: I58e86f8b3c65f46c24fc3102a859867bccb6a713
  1 file changed, 3 insertions(+)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index e397c4c58..214c62215 100644
+index e397c4c..214c622 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
 @@ -117,6 +117,9 @@ static void LoadBootScripts(ActionManager& action_manager, ServiceList& service_
@@ -28,5 +27,5 @@ index e397c4c58..214c62215 100644
              late_import_paths.emplace_back("/product/etc/init");
          }
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0028-hybris-disable-remnants-of-SELinux-which-currently-b.patch
+++ b/system/core/0028-hybris-disable-remnants-of-SELinux-which-currently-b.patch
@@ -1,8 +1,7 @@
-From 3dc6e2087d6f91c231811650634fd692c5c339ac Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:32:06 +0200
-Subject: [PATCH 28/41] (hybris) disable remnants of SELinux which currently
- break
+Subject: [PATCH] (hybris) disable remnants of SELinux which currently break
 
 Change-Id: I252a8399c9853d993fc17d769bfbb2e4c722cfe8
 ---
@@ -10,7 +9,7 @@ Change-Id: I252a8399c9853d993fc17d769bfbb2e4c722cfe8
  1 file changed, 4 insertions(+)
 
 diff --git a/init/util.cpp b/init/util.cpp
-index 8eb184da9..e27f4f88e 100644
+index 8eb184d..e27f4f8 100644
 --- a/init/util.cpp
 +++ b/init/util.cpp
 @@ -87,12 +87,14 @@ Result<uid_t> DecodeUid(const std::string& name) {
@@ -39,5 +38,5 @@ index 8eb184da9..e27f4f88e 100644
      struct sockaddr_un addr;
      memset(&addr, 0 , sizeof(addr));
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0029-hybris-disable-the-usage-of-libprocessgroup-since-it.patch
+++ b/system/core/0029-hybris-disable-the-usage-of-libprocessgroup-since-it.patch
@@ -1,8 +1,8 @@
-From 78f3c5f4270a70af8ee7d40a35fccb5da6ee12bc Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:33:03 +0200
-Subject: [PATCH 29/41] (hybris) disable the usage of libprocessgroup, since it
- is incompatible.
+Subject: [PATCH] (hybris) disable the usage of libprocessgroup, since it is
+ incompatible.
 
 Change-Id: Ie37ac0dcc5cabbf33de55c148009fdfff3e90c64
 ---
@@ -12,7 +12,7 @@ Change-Id: Ie37ac0dcc5cabbf33de55c148009fdfff3e90c64
  3 files changed, 11 insertions(+), 7 deletions(-)
 
 diff --git a/init/Android.bp b/init/Android.bp
-index 63c8382a4..3b6f46f53 100644
+index 63c8382..3b6f46f 100644
 --- a/init/Android.bp
 +++ b/init/Android.bp
 @@ -79,7 +79,6 @@ cc_defaults {
@@ -32,7 +32,7 @@ index 63c8382a4..3b6f46f53 100644
          "libcutils",
      ],
 diff --git a/init/Android.mk b/init/Android.mk
-index c4a6a50e5..d6fc5b5b9 100644
+index c4a6a50..d6fc5b5 100644
 --- a/init/Android.mk
 +++ b/init/Android.mk
 @@ -71,7 +71,6 @@ LOCAL_STATIC_LIBRARIES := \
@@ -44,7 +44,7 @@ index c4a6a50e5..d6fc5b5b9 100644
      libkeyutils \
      libprotobuf-cpp-lite \
 diff --git a/init/service.cpp b/init/service.cpp
-index 9c294af15..c2d8a383a 100644
+index 9c294af..c2d8a38 100644
 --- a/init/service.cpp
 +++ b/init/service.cpp
 @@ -36,7 +36,6 @@
@@ -97,5 +97,5 @@ index 9c294af15..c2d8a383a 100644
      NotifyStateChange("running");
      return Success();
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0030-hybris-disable-vendor-symlink.patch
+++ b/system/core/0030-hybris-disable-vendor-symlink.patch
@@ -1,7 +1,7 @@
-From 71a5d01caf197d3a4a14e2cecfd9727a03e2cefa Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Thu, 7 Jun 2018 15:29:53 +0000
-Subject: [PATCH 30/41] (hybris) disable vendor symlink
+Subject: [PATCH] (hybris) disable vendor symlink
 
 Change-Id: I26a32268e2f3af7ab0550397900f7a3ef0edfae5
 ---
@@ -9,7 +9,7 @@ Change-Id: I26a32268e2f3af7ab0550397900f7a3ef0edfae5
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index ec55903bb..a3432e2d4 100644
+index ec55903..a3432e2 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -52,7 +52,9 @@ on init
@@ -24,5 +24,5 @@ index ec55903bb..a3432e2d4 100644
      # Create energy-aware scheduler tuning nodes
      mkdir /dev/stune
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0031-hybris-ignore-mount-and-mkdir-tmp-commands-entirely.patch
+++ b/system/core/0031-hybris-ignore-mount-and-mkdir-tmp-commands-entirely.patch
@@ -1,8 +1,7 @@
-From 38087c05e0ae2555c9cf1322b0a06a1d28c66874 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 27 Aug 2018 11:08:12 +0000
-Subject: [PATCH 31/41] (hybris) ignore "mount" and "mkdir /tmp" commands
- entirely.
+Subject: [PATCH] (hybris) ignore "mount" and "mkdir /tmp" commands entirely.
 
 mount is usually removed during build, but if the *.rc files are on
 partitions we cannot easily change this is required (e.g. system,
@@ -21,7 +20,7 @@ Change-Id: Iba637613c6a927098c947536e11348e269e1bef3
  1 file changed, 16 insertions(+)
 
 diff --git a/init/builtins.cpp b/init/builtins.cpp
-index 8bb7b0f0c..23efc95b0 100644
+index 8bb7b0f..23efc95 100644
 --- a/init/builtins.cpp
 +++ b/init/builtins.cpp
 @@ -243,6 +243,13 @@ static Result<Success> do_insmod(const BuiltinArguments& args) {
@@ -73,5 +72,5 @@ index 8bb7b0f0c..23efc95b0 100644
  
  /* Imports .rc files from the specified paths. Default ones are applied if none is given.
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0032-hybris-Fix-actdead-charging-animation.-MER-1949.patch
+++ b/system/core/0032-hybris-Fix-actdead-charging-animation.-MER-1949.patch
@@ -1,14 +1,14 @@
-From b011b0d347d5d1bb2a9859205bc0feee9434bccb Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Thu, 30 Aug 2018 19:54:16 +0300
-Subject: [PATCH 32/41] (hybris) Fix actdead charging animation. MER#1949
+Subject: [PATCH] (hybris) Fix actdead charging animation. MER#1949
 
 ---
  rootdir/init.rc | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index a3432e2d4..7755d6117 100644
+index a3432e2..7755d61 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -698,7 +698,7 @@ on property:droid.late_start=trigger_late_start
@@ -21,5 +21,5 @@ index a3432e2d4..7755d6117 100644
  on property:vold.decrypt=trigger_reset_main
      class_reset main
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0033-hybris-system-core-Disable-usb-config.patch
+++ b/system/core/0033-hybris-system-core-Disable-usb-config.patch
@@ -1,7 +1,7 @@
-From b7ef832c8fdfa7e3b092e39c82eadcfd245414d1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Matti Kosola <matti.kosola@jolla.com>
 Date: Tue, 21 Feb 2017 13:13:26 +0100
-Subject: [PATCH 33/41] (hybris)[system/core] Disable usb config.
+Subject: [PATCH] (hybris)[system/core] Disable usb config.
 
 Signed-off-by: Matti Kosola <matti.kosola@jolla.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Matti Kosola <matti.kosola@jolla.com>
  1 file changed, 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 7755d6117..a6ba4a2b2 100644
+index 7755d61..a6ba4a2 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -14,7 +14,6 @@ import /init.environ.rc
@@ -21,5 +21,5 @@ index 7755d6117..a6ba4a2b2 100644
  
  on early-init
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0034-hybris-Remove-sbin-from-droid-PATH.patch
+++ b/system/core/0034-hybris-Remove-sbin-from-droid-PATH.patch
@@ -1,14 +1,14 @@
-From 2427f5942cde6d1ddd44e42443521a4d5a14cab9 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jussi Laakkonen <jussi.laakkonen@jolla.com>
 Date: Wed, 31 Jan 2018 17:12:14 +0200
-Subject: [PATCH 34/41] (hybris) Remove /sbin from droid PATH.
+Subject: [PATCH] (hybris) Remove /sbin from droid PATH.
 
 ---
  rootdir/init.environ.rc.in | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/rootdir/init.environ.rc.in b/rootdir/init.environ.rc.in
-index 516dc82f6..90c2b64d6 100644
+index 516dc82..90c2b64 100644
 --- a/rootdir/init.environ.rc.in
 +++ b/rootdir/init.environ.rc.in
 @@ -1,7 +1,7 @@
@@ -21,5 +21,5 @@ index 516dc82f6..90c2b64d6 100644
      # Hopefully now it is - ghosalmartin
      # this breaks mixed 32/64-bit devices -mal
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0035-hybris-Fix-return-value-type-of-mount-command.patch
+++ b/system/core/0035-hybris-Fix-return-value-type-of-mount-command.patch
@@ -1,7 +1,7 @@
-From c37a329c34808a5430a7d2fe443c8685589d9df6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Sun, 18 Nov 2018 18:51:22 +0200
-Subject: [PATCH 35/41] (hybris) Fix return value type of mount command.
+Subject: [PATCH] (hybris) Fix return value type of mount command.
 
 Change-Id: Ib759e1be92d110863e43f13f7317372c6182a02d
 ---
@@ -9,7 +9,7 @@ Change-Id: Ib759e1be92d110863e43f13f7317372c6182a02d
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/init/builtins.cpp b/init/builtins.cpp
-index 23efc95b0..4e2bce361 100644
+index 23efc95..4e2bce3 100644
 --- a/init/builtins.cpp
 +++ b/init/builtins.cpp
 @@ -589,7 +589,7 @@ static Result<Success> do_mount_all(const BuiltinArguments& args) {
@@ -22,5 +22,5 @@ index 23efc95b0..4e2bce361 100644
  
      if (import_rc) {
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0036-hybris-disable-some-more-selinux-functionality.patch
+++ b/system/core/0036-hybris-disable-some-more-selinux-functionality.patch
@@ -1,7 +1,7 @@
-From da41f7558ba050aad4dbc9e0b1b75e40e2d3bed6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <f_haider@gmx.at>
 Date: Thu, 28 Mar 2019 12:46:12 -0400
-Subject: [PATCH 36/41] (hybris) disable some more selinux functionality.
+Subject: [PATCH] (hybris) disable some more selinux functionality.
 
 Change-Id: Ie63eb13b73d626668b32041fec4400cf2edd2fe5
 ---
@@ -11,7 +11,7 @@ Change-Id: Ie63eb13b73d626668b32041fec4400cf2edd2fe5
  3 files changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/init/property_service.cpp b/init/property_service.cpp
-index 5bead058c..f0d345326 100644
+index 5bead05..f0d3453 100644
 --- a/init/property_service.cpp
 +++ b/init/property_service.cpp
 @@ -338,11 +338,14 @@ class SocketConnection {
@@ -30,7 +30,7 @@ index 5bead058c..f0d345326 100644
  
    private:
 diff --git a/init/subcontext.cpp b/init/subcontext.cpp
-index fdb46415d..5fbe8fc40 100644
+index fdb4641..5fbe8fc 100644
 --- a/init/subcontext.cpp
 +++ b/init/subcontext.cpp
 @@ -243,11 +243,11 @@ void Subcontext::Fork() {
@@ -48,7 +48,7 @@ index fdb46415d..5fbe8fc40 100644
          auto child_fd_string = std::to_string(child_fd);
          const char* args[] = {init_path.c_str(), "subcontext", context_.c_str(),
 diff --git a/init/util.cpp b/init/util.cpp
-index e27f4f88e..a5c95df5b 100644
+index e27f4f8..a5c95df 100644
 --- a/init/util.cpp
 +++ b/init/util.cpp
 @@ -117,10 +117,12 @@ int CreateSocket(const char* name, int type, bool passcred, mode_t perm, uid_t u
@@ -77,5 +77,5 @@ index e27f4f88e..a5c95df5b 100644
      if (ret) {
          errno = savederrno;
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0037-hybris-Disable-mnt-tmpfs-creation.patch
+++ b/system/core/0037-hybris-Disable-mnt-tmpfs-creation.patch
@@ -1,7 +1,7 @@
-From d138f79e6fe999fb2d6290825d413003069f3d6e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 3 Jun 2019 13:46:44 +0200
-Subject: [PATCH 37/41] (hybris) Disable /mnt tmpfs creation
+Subject: [PATCH] (hybris) Disable /mnt tmpfs creation
 
 Change-Id: I7c4fb119475adc345104f6ac5a68b578b6b2d433
 ---
@@ -9,7 +9,7 @@ Change-Id: I7c4fb119475adc345104f6ac5a68b578b6b2d433
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index 214c62215..7fe36d504 100644
+index 214c622..7fe36d5 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
 @@ -601,8 +601,8 @@ int main(int argc, char** argv) {
@@ -24,5 +24,5 @@ index 214c62215..7fe36d504 100644
          // part of the vendor partition, e.g. because they are mounted read-write.
          mkdir("/mnt/vendor", 0755);
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0038-hybris-Disable-init_user0-which-is-not-needed-on-Mer.patch
+++ b/system/core/0038-hybris-Disable-init_user0-which-is-not-needed-on-Mer.patch
@@ -1,14 +1,14 @@
-From 13125d52945d173b254aaebd56ae51cc807e2cb1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@jolla.com>
 Date: Mon, 10 Dec 2018 12:11:06 +0200
-Subject: [PATCH 38/41] (hybris) Disable init_user0 which is not needed on Mer.
+Subject: [PATCH] (hybris) Disable init_user0 which is not needed on Mer.
 
 ---
  rootdir/init.rc | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index a6ba4a2b2..c5a6a0bc0 100644
+index a6ba4a2..c5a6a0b 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -550,7 +550,8 @@ on post-fs-data
@@ -22,5 +22,5 @@ index a6ba4a2b2..c5a6a0bc0 100644
      # Set SELinux security contexts on upgrade or policy update.
      restorecon --recursive --skip-ce /data
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0039-hybris-Disable-SELinux-init.patch
+++ b/system/core/0039-hybris-Disable-SELinux-init.patch
@@ -1,7 +1,7 @@
-From 475be6b868e08dbcb49f5730f7b2e6332a37e3d4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Matti Kosola <matti.kosola@jolla.com>
 Date: Wed, 4 Sep 2019 12:07:34 +0200
-Subject: [PATCH 39/41] (hybris) Disable SELinux init.
+Subject: [PATCH] (hybris) Disable SELinux init.
 
 Sailfish OS SELinux initialization is done by systemd.
 Conflicting init has been resolved by disabling SELinux
@@ -14,7 +14,7 @@ Signed-off-by: Matti Kosola <matti.kosola@jolla.com>
  1 file changed, 8 insertions(+)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index 7fe36d504..ce2100c57 100644
+index 7fe36d5..ce2100c 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
 @@ -70,6 +70,8 @@ using android::base::StringPrintf;
@@ -66,5 +66,5 @@ index 7fe36d504..ce2100c57 100644
      epoll_fd = epoll_create1(EPOLL_CLOEXEC);
      if (epoll_fd == -1) {
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0040-hybris-Allow-input-group-to-use-vibrator.patch
+++ b/system/core/0040-hybris-Allow-input-group-to-use-vibrator.patch
@@ -1,8 +1,8 @@
-From e1ca562a7e324885fa14dd58651bc622ebd6f9cc Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
  <juho.hamalainen@jolla.com>
 Date: Mon, 23 Mar 2020 17:40:04 +0200
-Subject: [PATCH 40/40] (hybris) Allow input group to use vibrator.
+Subject: [PATCH] (hybris) Allow input group to use vibrator.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -15,7 +15,7 @@ Signed-off-by: Juho Hämäläinen <juho.hamalainen@jolla.com>
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index c5a6a0bc0..b2f6540ab 100644
+index c5a6a0b..b2f6540 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -649,10 +649,11 @@ on boot
@@ -33,5 +33,5 @@ index c5a6a0bc0..b2f6540ab 100644
      chown system system /sys/class/timed_output/vibrator/enable
      chown system system /sys/class/leds/keyboard-backlight/brightness
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0041-hybris-Allow-input-group-to-use-old-vibrator.patch
+++ b/system/core/0041-hybris-Allow-input-group-to-use-old-vibrator.patch
@@ -1,8 +1,8 @@
-From 324315555140ca5fb378286dcd166f9750cba627 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
  <juho.hamalainen@jolla.com>
 Date: Tue, 24 Mar 2020 14:07:40 +0200
-Subject: [PATCH 41/41] (hybris) Allow input group to use old vibrator.
+Subject: [PATCH] (hybris) Allow input group to use old vibrator.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -13,7 +13,7 @@ Signed-off-by: Juho Hämäläinen <juho.hamalainen@jolla.com>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index b2f6540ab..e33f89132 100644
+index b2f6540..e33f891 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -655,7 +655,8 @@ on boot
@@ -27,5 +27,5 @@ index b2f6540ab..e33f89132 100644
      chown system system /sys/class/leds/lcd-backlight/brightness
      chown system system /sys/class/leds/button-backlight/brightness
 -- 
-2.20.1
+2.7.4
 

--- a/system/core/0042-hybris-Remove-dev-cg2_bpf-cgroup-device.patch
+++ b/system/core/0042-hybris-Remove-dev-cg2_bpf-cgroup-device.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matti Kosola <matti.kosola@jolla.com>
+Date: Mon, 14 Dec 2020 15:55:58 +0100
+Subject: [PATCH] (hybris) Remove /dev/cg2_bpf cgroup device.
+
+Systemd v238 mixes cgroup permissions if something else is
+changing permissions of cgroup mounted devices. This cg2_bpf
+device is used by netd and it is not running in Sailfish OS.
+
+Change-Id: Ie0de704f977a21505d5bb66e1bc571818173baab
+Signed-off-by: Matti Kosola <matti.kosola@jolla.com>
+---
+ rootdir/init.rc | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/rootdir/init.rc b/rootdir/init.rc
+index e33f891..0431a96 100644
+--- a/rootdir/init.rc
++++ b/rootdir/init.rc
+@@ -224,10 +224,6 @@ on init
+     # This is needed by any process that uses socket tagging.
+     chmod 0644 /dev/xt_qtaguid
+ 
+-    mkdir /dev/cg2_bpf
+-    mount cgroup2 cg2_bpf /dev/cg2_bpf nodev noexec nosuid
+-    chown root root /dev/cg2_bpf
+-    chmod 0600 /dev/cg2_bpf
+     mount bpf bpf /sys/fs/bpf nodev noexec nosuid
+ 
+     # Create location for fs_mgr to store abbreviated output from filesystem
+-- 
+2.7.4
+


### PR DESCRIPTION
Systemd v238 mixes cgroup permissions if something else is changing permissions of cgroup mounted devices. This cg2_bpf device is used by netd and it is not running in Sailfish OS.