### PR TITLE
frameworks: native: pick egl/gles libraries from the correct path also in the 64 bit case.

### DIFF
--- a/art/0001-hybris-Silence-some-build-errors-to-let-the-systemim.patch
+++ b/art/0001-hybris-Silence-some-build-errors-to-let-the-systemim.patch
@@ -1,4 +1,4 @@
-From 1a27bd48255a96853e49d25c82a0fe47dd477f83 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Bj=C3=B6rn=20Bidar?= <theodorstormgrade@gmail.com>
 Date: Fri, 3 Jul 2020 22:15:49 +0200
 Subject: [PATCH] (hybris) Silence some build errors to let the systemimage
@@ -21,7 +21,7 @@ Change-Id: Ide41188b6263a22c371ec28786bbc1ef1ee62df7
  4 files changed, 17 insertions(+), 11 deletions(-)
 
 diff --git a/build/Android.gtest.mk b/build/Android.gtest.mk
-index 03aae07587..20e38df7b2 100644
+index 03aae07587d9f21ffcb1a0e3707ef32d003a80ee..20e38df7b2d18282fe63acea79097d7bb9e975f4 100644
 --- a/build/Android.gtest.mk
 +++ b/build/Android.gtest.mk
 @@ -73,28 +73,28 @@ $(foreach dir,$(GTEST_DEX_DIRECTORIES), $(eval $(call build-art-test-dex,art-gte
@@ -64,7 +64,7 @@ index 03aae07587..20e38df7b2 100644
  ifdef ART_TEST_HOST_GTEST_Main_DEX
  $(ART_TEST_HOST_GTEST_MainStripped_DEX): $(ART_TEST_HOST_GTEST_Main_DEX)
 diff --git a/runtime/thread-current-inl.h b/runtime/thread-current-inl.h
-index 9241b1f875..a3e0520423 100644
+index 9241b1f875bceba4164598adf74535142af821b5..a3e05204230e7e760d71cd80a1c98500248689b3 100644
 --- a/runtime/thread-current-inl.h
 +++ b/runtime/thread-current-inl.h
 @@ -34,7 +34,7 @@ inline Thread* Thread::Current() {
@@ -77,7 +77,7 @@ index 9241b1f875..a3e0520423 100644
      void* thread = pthread_getspecific(Thread::pthread_key_self_);
  #endif
 diff --git a/runtime/thread.cc b/runtime/thread.cc
-index be0e30ad11..da112e19c9 100644
+index be0e30ad11e5586d4b1c26dadde34d5784173a2f..da112e19c9134008ff2058bc707f89d75317eee3 100644
 --- a/runtime/thread.cc
 +++ b/runtime/thread.cc
 @@ -933,7 +933,9 @@ bool Thread::Init(ThreadList* thread_list, JavaVMExt* java_vm, JNIEnvExt* jni_en
@@ -101,7 +101,7 @@ index be0e30ad11..da112e19c9 100644
      CHECK_PTHREAD_CALL(pthread_setspecific, (Thread::pthread_key_self_, self), "reattach self");
  #endif
 diff --git a/runtime/thread_list.cc b/runtime/thread_list.cc
-index ed6b2c91e5..37a2bd6911 100644
+index ed6b2c91e5b30ae2acadb183ba096936c9572217..37a2bd69117373bcc551918c36fb2c99623d2303 100644
 --- a/runtime/thread_list.cc
 +++ b/runtime/thread_list.cc
 @@ -1482,7 +1482,9 @@ void ThreadList::Unregister(Thread* self) {
@@ -114,6 +114,3 @@ index ed6b2c91e5..37a2bd6911 100644
  #else
    CHECK_PTHREAD_CALL(pthread_setspecific, (Thread::pthread_key_self_, nullptr), "detach self");
  #endif
--- 
-2.27.0
-

--- a/bionic/0001-hybris-Add-support-for-get-and-list-of-properties.patch
+++ b/bionic/0001-hybris-Add-support-for-get-and-list-of-properties.patch
@@ -1,7 +1,7 @@
-From cd7b68932bccda2eac104c841254f90c50359cf7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Sun, 17 Dec 2017 00:16:16 +0200
-Subject: [PATCH 1/7] (hybris) Add support for get and list of properties.
+Subject: [PATCH] (hybris) Add support for get and list of properties.
 
 Change-Id: I089a2a146c06d8ad0c234f0a9a4b5aa07beaeed5
 ---
@@ -9,7 +9,7 @@ Change-Id: I089a2a146c06d8ad0c234f0a9a4b5aa07beaeed5
  1 file changed, 2 insertions(+)
 
 diff --git a/libc/include/sys/_system_properties.h b/libc/include/sys/_system_properties.h
-index 744a45b71..2f32bc28f 100644
+index 744a45b71f5ef9cca938687c9cfb511eb85820ad..2f32bc28ff6f583bd6aa6ecce55f504fbb5d5d55 100644
 --- a/libc/include/sys/_system_properties.h
 +++ b/libc/include/sys/_system_properties.h
 @@ -44,6 +44,8 @@ __BEGIN_DECLS
@@ -21,6 +21,3 @@ index 744a45b71..2f32bc28f 100644
  #define PROP_MSG_SETPROP2 0x00020001
  
  #define PROP_SUCCESS 0
--- 
-2.27.0
-

--- a/bionic/0002-hybris-bionic_tls.h-shifting-TLS-slots-to-avoid-conf.patch
+++ b/bionic/0002-hybris-bionic_tls.h-shifting-TLS-slots-to-avoid-conf.patch
@@ -1,8 +1,8 @@
-From 8da8433158fc287697bba8809218822781f386f5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
 Date: Thu, 9 Jan 2014 00:57:01 -0200
-Subject: [PATCH 2/7] (hybris) bionic_tls.h: shifting TLS slots to avoid
- conflicts with libc/hybris
+Subject: [PATCH] (hybris) bionic_tls.h: shifting TLS slots to avoid conflicts
+ with libc/hybris
 
 Change-Id: Idf503fe8fa0a24edf4dbbabaa8d3a1c2d1f60295
 Signed-off-by: Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
@@ -14,7 +14,7 @@ Conflicts:
  1 file changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/libc/private/bionic_asm_tls.h b/libc/private/bionic_asm_tls.h
-index 92f707aad..40e6a5394 100644
+index 92f707aadab0173bd59696d510501f068347b203..40e6a53941a98feaab7059cc33acc4a7fe6a8257 100644
 --- a/libc/private/bionic_asm_tls.h
 +++ b/libc/private/bionic_asm_tls.h
 @@ -84,12 +84,12 @@
@@ -36,6 +36,3 @@ index 92f707aad..40e6a5394 100644
  
  // The maximum slot is fixed by the minimum TLS alignment in Bionic executables.
  #define MAX_TLS_SLOT              7
--- 
-2.27.0
-

--- a/bionic/0003-hybris-disable-tls-usage-in-locale.cpp-to-avoid-prob.patch
+++ b/bionic/0003-hybris-disable-tls-usage-in-locale.cpp-to-avoid-prob.patch
@@ -1,8 +1,8 @@
-From d5ca09b790c93dbf6f9522743a975fe2817dc03d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Wed, 18 Apr 2018 18:37:09 +0200
-Subject: [PATCH 3/7] (hybris) disable tls usage in locale.cpp, to avoid
- problems with libhybris
+Subject: [PATCH] (hybris) disable tls usage in locale.cpp, to avoid problems
+ with libhybris
 
 Change-Id: I498a9749853e6a5a4aaa4ae93479aff083e02d4c
 Signed-off-by: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
@@ -11,7 +11,7 @@ Signed-off-by: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/libc/bionic/locale.cpp b/libc/bionic/locale.cpp
-index 8358fb0ab..8def0e164 100644
+index 8358fb0abd578b942e4500b591f0134c2cd7be03..8def0e164e3b74575681defc4a53746416e31039 100644
 --- a/libc/bionic/locale.cpp
 +++ b/libc/bionic/locale.cpp
 @@ -37,11 +37,11 @@
@@ -30,6 +30,3 @@ index 8358fb0ab..8def0e164 100644
  
  #if USE_TLS_SLOT
  #include "bionic/pthread_internal.h"
--- 
-2.27.0
-

--- a/bionic/0004-hybris-Fix-TLS-slots-for-x86-Aligns-with-this-libhyb.patch
+++ b/bionic/0004-hybris-Fix-TLS-slots-for-x86-Aligns-with-this-libhyb.patch
@@ -1,7 +1,7 @@
-From 480a63cbf69884a8e274c305eccd3ac676e02a74 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ilya Bizyaev <bizyaev@zoho.com>
 Date: Sat, 20 Jan 2018 17:48:27 +0300
-Subject: [PATCH 4/7] (hybris) Fix TLS slots for x86 Aligns with this libhybris
+Subject: [PATCH] (hybris) Fix TLS slots for x86 Aligns with this libhybris
  patch: https://github.com/libhybris/libhybris/pull/370
 
 Change-Id: Ibdbfa1c1672cbac5a687afdedbb1d8ff05861f4f
@@ -10,7 +10,7 @@ Change-Id: Ibdbfa1c1672cbac5a687afdedbb1d8ff05861f4f
  1 file changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/libc/private/bionic_asm_tls.h b/libc/private/bionic_asm_tls.h
-index 40e6a5394..07ded2005 100644
+index 40e6a53941a98feaab7059cc33acc4a7fe6a8257..07ded20059c1dbe33db568be80b75666e3cfc14d 100644
 --- a/libc/private/bionic_asm_tls.h
 +++ b/libc/private/bionic_asm_tls.h
 @@ -104,12 +104,12 @@
@@ -32,6 +32,3 @@ index 40e6a5394..07ded2005 100644
  #define TLS_SLOT_DTV              8
  #define TLS_SLOT_BIONIC_TLS       9
  #define MAX_TLS_SLOT              9 // update this value when reserving a slot
--- 
-2.27.0
-

--- a/bionic/0005-hybris-don-t-fail-because-of-fsetxattr.patch
+++ b/bionic/0005-hybris-don-t-fail-because-of-fsetxattr.patch
@@ -1,7 +1,7 @@
-From c806b95a09f6ca97c44025a97ca5bddb7cec6162 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <f_haider@gmx.at>
 Date: Thu, 28 Mar 2019 13:10:48 -0400
-Subject: [PATCH 5/7] (hybris) don't fail because of fsetxattr
+Subject: [PATCH] (hybris) don't fail because of fsetxattr
 
 Change-Id: I4d765ff401d6b4f12da0305416cb751eb0c9e96b
 ---
@@ -9,7 +9,7 @@ Change-Id: I4d765ff401d6b4f12da0305416cb751eb0c9e96b
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libc/system_properties/prop_area.cpp b/libc/system_properties/prop_area.cpp
-index 42bee9f3e..04be16230 100644
+index 42bee9f3ea9b0a94704b0d86403cdcf3ecd13d92..04be16230a91fc7cf32c9519717be152b39fdb7a 100644
 --- a/libc/system_properties/prop_area.cpp
 +++ b/libc/system_properties/prop_area.cpp
 @@ -79,7 +79,7 @@ prop_area* prop_area::map_prop_area_rw(const char* filename, const char* context
@@ -21,6 +21,3 @@ index 42bee9f3e..04be16230 100644
        }
      }
    }
--- 
-2.27.0
-

--- a/bionic/0006-hybris-Fix-__get_tls-and-related-functions-Android-1.patch
+++ b/bionic/0006-hybris-Fix-__get_tls-and-related-functions-Android-1.patch
@@ -1,8 +1,7 @@
-From a52e2b68710dec02a46768b485ab50b0a193834c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Thu, 8 Oct 2020 14:43:42 +0000
-Subject: [PATCH 6/7] (hybris) Fix __get_tls and related functions (>=Android
- 10)
+Subject: [PATCH] (hybris) Fix __get_tls and related functions (>=Android 10)
 
 Signed-off-by: Simonas Leleiva <simonas.leleiva@jolla.com>
 Change-Id: I24486873be638a1a8cd123705ba2e51ec7414b94
@@ -18,7 +17,7 @@ Change-Id: I24486873be638a1a8cd123705ba2e51ec7414b94
  create mode 100644 libc/private/__get_tls_internal.h
 
 diff --git a/libc/Android.bp b/libc/Android.bp
-index a5990288d..85e03f4a2 100644
+index a5990288d212751c136ed1060208a6cde0859f93..85e03f4a21dba3f330b61a41b92870a34a2c233b 100644
 --- a/libc/Android.bp
 +++ b/libc/Android.bp
 @@ -18,6 +18,7 @@ libc_common_src_files = [
@@ -30,7 +29,7 @@ index a5990288d..85e03f4a2 100644
  
  // Various kinds of cruft.
 diff --git a/libc/bionic/ndk_cruft.cpp b/libc/bionic/ndk_cruft.cpp
-index 2c3299f7b..85626db4a 100644
+index 2c3299f7b8e45b184ea5913122ae3b1cd969aa02..85626db4a838068639bdc0e7cee3400ea40dd36a 100644
 --- a/libc/bionic/ndk_cruft.cpp
 +++ b/libc/bionic/ndk_cruft.cpp
 @@ -49,6 +49,13 @@
@@ -62,7 +61,7 @@ index 2c3299f7b..85626db4a 100644
    char* p = reinterpret_cast<char*>(m1);
 diff --git a/libc/hybris_support.c b/libc/hybris_support.c
 new file mode 100644
-index 000000000..925253021
+index 0000000000000000000000000000000000000000..9252530211b64d6115c7f930fc32d08937d008fc
 --- /dev/null
 +++ b/libc/hybris_support.c
 @@ -0,0 +1,4 @@
@@ -71,7 +70,7 @@ index 000000000..925253021
 +  return __get_tls_internal();
 +}
 diff --git a/libc/libc.map.txt b/libc/libc.map.txt
-index 88192239a..941faadf8 100644
+index 88192239a1ace8e4a5068720fbdbbcc6b6f0fa8a..941faadf8082650d33ea634351f56639658703d2 100644
 --- a/libc/libc.map.txt
 +++ b/libc/libc.map.txt
 @@ -40,6 +40,7 @@ LIBC {
@@ -83,7 +82,7 @@ index 88192239a..941faadf8 100644
      __getcpu; # arm x86 mips introduced-arm=12 introduced-mips=16 introduced-x86=12
      __getcwd; # arm x86 mips
 diff --git a/libc/private/__get_tls.h b/libc/private/__get_tls.h
-index 04c5fdbbf..6a4b5728e 100644
+index 04c5fdbbf15ad6b63e4755d700c7d36fad53f37f..6a4b5728e088857f4b5696e197a5893521e6b8b1 100644
 --- a/libc/private/__get_tls.h
 +++ b/libc/private/__get_tls.h
 @@ -29,25 +29,18 @@
@@ -126,7 +125,7 @@ index 04c5fdbbf..6a4b5728e 100644
  #endif /* __BIONIC_PRIVATE_GET_TLS_H_ */
 diff --git a/libc/private/__get_tls_internal.h b/libc/private/__get_tls_internal.h
 new file mode 100644
-index 000000000..4a8fa5fc2
+index 0000000000000000000000000000000000000000..4a8fa5fc20d522cc39c9840176b42df6d799d4cf
 --- /dev/null
 +++ b/libc/private/__get_tls_internal.h
 @@ -0,0 +1,54 @@
@@ -184,6 +183,3 @@ index 000000000..4a8fa5fc2
 +
 +#endif /* __BIONIC_PRIVATE_GET_TLS_INTERNAL_H_ */
 +
--- 
-2.27.0
-

--- a/bionic/0007-halium-libdl-neutralize-cfi_slowpath_common-as-it-br.patch
+++ b/bionic/0007-halium-libdl-neutralize-cfi_slowpath_common-as-it-br.patch
@@ -1,8 +1,8 @@
-From 3b2cfa4a631f91910300badccf93a40749d43817 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: NeKit <nekit1000@gmail.com>
 Date: Fri, 3 Jul 2020 20:10:20 +0200
-Subject: [PATCH 7/7] (halium) libdl: neutralize cfi_slowpath_common as it
- breaks libhybris
+Subject: [PATCH] (halium) libdl: neutralize cfi_slowpath_common as it breaks
+ libhybris
 
 Change-Id: I90b4af9d9e6b23cccafb659931a8e85b8bae091a
 ---
@@ -10,7 +10,7 @@ Change-Id: I90b4af9d9e6b23cccafb659931a8e85b8bae091a
  1 file changed, 1 insertion(+)
 
 diff --git a/libdl/libdl_cfi.cpp b/libdl/libdl_cfi.cpp
-index 1dd5b21cd..f48a3cfef 100644
+index 1dd5b21cd37e1b8ee3888f05f9f810e17a4355ba..f48a3cfef0057f996df337cd7dc1013fcfa0c3c0 100644
 --- a/libdl/libdl_cfi.cpp
 +++ b/libdl/libdl_cfi.cpp
 @@ -66,6 +66,7 @@ static uintptr_t cfi_check_addr(uint16_t v, void* Ptr) {
@@ -21,6 +21,3 @@ index 1dd5b21cd..f48a3cfef 100644
    uint16_t v = shadow_load(Ptr);
    switch (v) {
      case CFIShadow::kInvalidShadow:
--- 
-2.27.0
-

--- a/build/make/0001-hybris-Reduce-vendorimage-build-size.patch
+++ b/build/make/0001-hybris-Reduce-vendorimage-build-size.patch
@@ -1,7 +1,7 @@
-From cba9bc8e5c67b75f2332412c6382e4feef79808e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Fri, 22 Mar 2019 18:36:56 +0200
-Subject: [PATCH 1/3] (hybris) Reduce vendorimage build size.
+Subject: [PATCH] (hybris) Reduce vendorimage build size.
 
 Change-Id: Id025a7d7c81cb19c2881ff6619084b638ce983fb
 ---
@@ -9,7 +9,7 @@ Change-Id: Id025a7d7c81cb19c2881ff6619084b638ce983fb
  1 file changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/core/Makefile b/core/Makefile
-index df3a161c1..feb17c37b 100644
+index df3a161c12c78cdf49e6a65f80a35410e45f42c7..feb17c37bfb3a0b428d439f6f5a49f4345b40024 100644
 --- a/core/Makefile
 +++ b/core/Makefile
 @@ -19,6 +19,7 @@ $(if $(filter-out $(TARGET_COPY_OUT_SYSTEM_OTHER)/%,$(2)), \
@@ -51,6 +51,3 @@ index df3a161c1..feb17c37b 100644
  
  .PHONY: vendorimage-nodeps vnod
  vendorimage-nodeps vnod: | $(INTERNAL_USERIMAGES_DEPS) $(DEPMOD)
--- 
-2.27.0
-

--- a/build/make/0002-hybris-build-minimization-might-be-improveable-but-t.patch
+++ b/build/make/0002-hybris-build-minimization-might-be-improveable-but-t.patch
@@ -1,8 +1,8 @@
-From a81cf1a739d91dd23fe91984b8c170265a14d5df Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Thu, 7 Jun 2018 15:32:40 +0000
-Subject: [PATCH 2/3] (hybris) build minimization (might be improveable, but
- this version doesn't break dependancies)
+Subject: [PATCH] (hybris) build minimization (might be improveable, but this
+ version doesn't break dependancies)
 
 Change-Id: Ic862dc084f5f4e3fa7ccd90b0757deff0f17b802
 ---
@@ -21,7 +21,7 @@ Change-Id: Ic862dc084f5f4e3fa7ccd90b0757deff0f17b802
  12 files changed, 11 insertions(+), 879 deletions(-)
 
 diff --git a/core/dex_preopt.mk b/core/dex_preopt.mk
-index 180edafbb..e69de29bb 100644
+index 180edafbbb223522b91d5678ce1bce49a7feacc2..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 100644
 --- a/core/dex_preopt.mk
 +++ b/core/dex_preopt.mk
 @@ -1,49 +0,0 @@
@@ -75,7 +75,7 @@ index 180edafbb..e69de29bb 100644
 -endif  #PRODUCT_USES_ART
 -endif  #WITH_DEXPREOPT
 diff --git a/core/envsetup.mk b/core/envsetup.mk
-index 5131598a9..3e7b35b1a 100644
+index 5131598a940bca162e287ad56910215dfa36ec44..3e7b35b1a3c58dd87ed05b930164598e70a6edb7 100644
 --- a/core/envsetup.mk
 +++ b/core/envsetup.mk
 @@ -250,8 +250,8 @@ endef
@@ -90,7 +90,7 @@ index 5131598a9..3e7b35b1a 100644
    ifneq ($(EMMA_INSTRUMENT_STATIC),true)
      # For instrumented build, if Jacoco is not being included statically
 diff --git a/core/host_dalvik_java_library.mk b/core/host_dalvik_java_library.mk
-index 2a251e84e..8b1378917 100644
+index 2a251e84e585c7fd208acf5aa99f059028f78535..8b137891791fe96927ad78e64b0aad7bded08bdc 100644
 --- a/core/host_dalvik_java_library.mk
 +++ b/core/host_dalvik_java_library.mk
 @@ -1,192 +1 @@
@@ -287,7 +287,7 @@ index 2a251e84e..8b1378917 100644
 -
 -endif
 diff --git a/core/host_dalvik_static_java_library.mk b/core/host_dalvik_static_java_library.mk
-index 78faf73a5..e69de29bb 100644
+index 78faf73a562c35e77b699ef5dfa68c2433e7322b..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 100644
 --- a/core/host_dalvik_static_java_library.mk
 +++ b/core/host_dalvik_static_java_library.mk
 @@ -1,28 +0,0 @@
@@ -320,7 +320,7 @@ index 78faf73a5..e69de29bb 100644
 -
 -LOCAL_IS_STATIC_JAVA_LIBRARY :=
 diff --git a/core/host_java_library.mk b/core/host_java_library.mk
-index c8d2ee78c..e69de29bb 100644
+index c8d2ee78c2cabb3cd11908e95de8a00b8b0861f2..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 100644
 --- a/core/host_java_library.mk
 +++ b/core/host_java_library.mk
 @@ -1,128 +0,0 @@
@@ -453,7 +453,7 @@ index c8d2ee78c..e69de29bb 100644
 -$(eval $(call copy-one-file,$(LOCAL_FULL_CLASSES_JACOCO_JAR),$(full_classes_header_jar)))
 -endif
 diff --git a/core/java_library.mk b/core/java_library.mk
-index c706cea72..e69de29bb 100644
+index c706cea72423f1ed52efb9ab8c97d52a0982381c..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 100644
 --- a/core/java_library.mk
 +++ b/core/java_library.mk
 @@ -1,100 +0,0 @@
@@ -558,7 +558,7 @@ index c706cea72..e69de29bb 100644
 -endif # LOCAL_DEX_PREOPT
 -endif # !LOCAL_IS_STATIC_JAVA_LIBRARY
 diff --git a/core/main.mk b/core/main.mk
-index a13404a99..86193c909 100644
+index a13404a99678861d2382478b08e33f6f51caff6e..86193c909d5de2770276b24affcf38b6f6f1ce27 100644
 --- a/core/main.mk
 +++ b/core/main.mk
 @@ -181,8 +181,6 @@ endif
@@ -581,7 +581,7 @@ index a13404a99..86193c909 100644
  # Bring in the PDK platform.zip modules.
  include $(BUILD_SYSTEM)/pdk_fusion_modules.mk
 diff --git a/core/package.mk b/core/package.mk
-index 854e0093c..e69de29bb 100644
+index 854e0093c66156fc36d9b90a866dcebc7e46f530..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 100644
 --- a/core/package.mk
 +++ b/core/package.mk
 @@ -1,86 +0,0 @@
@@ -672,7 +672,7 @@ index 854e0093c..e69de29bb 100644
 -
 -my_module_arch_supported :=
 diff --git a/core/soong_droiddoc_prebuilt.mk b/core/soong_droiddoc_prebuilt.mk
-index c0467df2b..496929963 100644
+index c0467df2be6dda1e8775c50d4f604c6b1768625c..49692996378e393408d7c1e306dd4e7085c7d4ed 100644
 --- a/core/soong_droiddoc_prebuilt.mk
 +++ b/core/soong_droiddoc_prebuilt.mk
 @@ -1,43 +1,3 @@
@@ -720,7 +720,7 @@ index c0467df2b..496929963 100644
  ifdef LOCAL_DROIDDOC_METADATA_ZIP
  $(eval $(call copy-one-file,$(LOCAL_DROIDDOC_METADATA_ZIP),$(TARGET_OUT_COMMON_INTERMEDIATES)/PACKAGING/$(LOCAL_MODULE)-metadata.zip))
 diff --git a/core/static_java_library.mk b/core/static_java_library.mk
-index ee759b9d8..e69de29bb 100644
+index ee759b9d8eb57c06ad12f0d3de31487c40e44cb1..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 100644
 --- a/core/static_java_library.mk
 +++ b/core/static_java_library.mk
 @@ -1,247 +0,0 @@
@@ -972,7 +972,7 @@ index ee759b9d8..e69de29bb 100644
 -all_res_assets :=
 -LOCAL_IS_STATIC_JAVA_LIBRARY :=
 diff --git a/target/product/base_system.mk b/target/product/base_system.mk
-index 2f8a63472..4fede2c5a 100644
+index 2f8a634729a2e169fa3046edf6402c296cc5160b..4fede2c5aa47e4ae31e86e11d4d30d3db5170054 100644
 --- a/target/product/base_system.mk
 +++ b/target/product/base_system.mk
 @@ -307,9 +307,9 @@ PRODUCT_HOST_PACKAGES += \
@@ -989,7 +989,7 @@ index 2f8a63472..4fede2c5a 100644
  # The order matters for runtime class lookup performance.
  PRODUCT_BOOT_JARS := \
 diff --git a/target/product/runtime_libart.mk b/target/product/runtime_libart.mk
-index a88ba3c8d..4ab27994b 100644
+index a88ba3c8d025c3fd4bc7739d94b1296cd9c1ff3f..4ab27994be605a49c33f841ed4b1bc2ff4e1b7e7 100644
 --- a/target/product/runtime_libart.mk
 +++ b/target/product/runtime_libart.mk
 @@ -16,9 +16,9 @@
@@ -1005,6 +1005,3 @@ index a88ba3c8d..4ab27994b 100644
  
  # Minimal boot classpath. This should be a subset of PRODUCT_BOOT_JARS, and equivalent to
  # TARGET_CORE_JARS.
--- 
-2.27.0
-

--- a/build/make/0003-hybris-Disable-APEX-check-we-don-t-care-about-it.patch
+++ b/build/make/0003-hybris-Disable-APEX-check-we-don-t-care-about-it.patch
@@ -1,7 +1,7 @@
-From 3043dd6090c1c0aa822251f258b734b85daac18a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Bj=C3=B6rn=20Bidar?= <theodorstormgrade@gmail.com>
 Date: Fri, 18 Oct 2019 11:43:31 +0200
-Subject: [PATCH 3/3] (hybris) Disable APEX check, we don't care about it.
+Subject: [PATCH] (hybris) Disable APEX check, we don't care about it.
 
 Change-Id: I1099755d6ec01f10b70c78ca68af822ccafb2b6f
 ---
@@ -9,7 +9,7 @@ Change-Id: I1099755d6ec01f10b70c78ca68af822ccafb2b6f
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/core/main.mk b/core/main.mk
-index 86193c909..71d828352 100644
+index 86193c909d5de2770276b24affcf38b6f6f1ce27..71d828352c1acb1e13e10228f72bf52c8e939731 100644
 --- a/core/main.mk
 +++ b/core/main.mk
 @@ -1259,7 +1259,7 @@ APEX_MODULE_LIBS += \
@@ -21,6 +21,3 @@ index 86193c909..71d828352 100644
  
  # Bionic should not be in /system, except for the bootstrap instance.
  APEX_LIBS_ABSENCE_CHECK_EXCLUDE := lib/bootstrap lib64/bootstrap
--- 
-2.27.0
-

--- a/frameworks/av/0001-hybris-AudioService-is-disabled-in-hybris-adaptation.patch
+++ b/frameworks/av/0001-hybris-AudioService-is-disabled-in-hybris-adaptation.patch
@@ -1,4 +1,4 @@
-From b2644d4d8077015b2bdc0eb2bd21117875dffbfe Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Sun, 30 Oct 2016 14:07:11 +0000
 Subject: [PATCH] (hybris) AudioService is disabled in hybris adaptations
@@ -16,7 +16,7 @@ Signed-off-by: Björn Bidar <theodorstormgrade@gmail.com>
  1 file changed, 7 insertions(+)
 
 diff --git a/services/camera/libcameraservice/CameraService.cpp b/services/camera/libcameraservice/CameraService.cpp
-index 670e026183..c8a4694722 100644
+index 670e02618312366c7db075a422547b4d0378549c..c8a469472264122e9b5cd2127e452ac8e5bfb698 100644
 --- a/services/camera/libcameraservice/CameraService.cpp
 +++ b/services/camera/libcameraservice/CameraService.cpp
 @@ -2275,9 +2275,15 @@ void CameraService::increaseSoundRef() {
@@ -43,6 +43,3 @@ index 670e026183..c8a4694722 100644
  }
  
  void CameraService::decreaseSoundRef() {
--- 
-2.23.0
-

--- a/frameworks/base/0001-hybris-Disable-some-tests-to-avoid-build-errors.patch
+++ b/frameworks/base/0001-hybris-Disable-some-tests-to-avoid-build-errors.patch
@@ -1,4 +1,4 @@
-From 79f3537ae0e6f7ec4f90eea3cb9964504bef59d2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Bj=C3=B6rn=20Bidar?= <theodorstormgrade@gmail.com>
 Date: Mon, 21 Oct 2019 07:12:52 +0200
 Subject: [PATCH] (hybris) Disable some tests to avoid build errors.
@@ -16,7 +16,7 @@ Signed-off-by: Björn Bidar <theodorstormgrade@gmail.com>
  1 file changed, 23 deletions(-)
 
 diff --git a/core/tests/hosttests/test-apps/MultiDexLegacyTestAppWithCorruptedDex/Android.mk b/core/tests/hosttests/test-apps/MultiDexLegacyTestAppWithCorruptedDex/Android.mk
-index a6f87ea2e5d..40c005e8e63 100644
+index a6f87ea2e5dff5ce1639f0317952b35ddf45dccf..40c005e8e6366097b653319d2eaba7fdc870e2bf 100644
 --- a/core/tests/hosttests/test-apps/MultiDexLegacyTestAppWithCorruptedDex/Android.mk
 +++ b/core/tests/hosttests/test-apps/MultiDexLegacyTestAppWithCorruptedDex/Android.mk
 @@ -13,26 +13,3 @@
@@ -46,6 +46,3 @@ index a6f87ea2e5d..40c005e8e63 100644
 -	$(hide) touch $@
 -
 -$(LOCAL_BUILT_MODULE): $(corrupted_classes2_dex)
--- 
-2.23.0
-

--- a/frameworks/native/0001-hybris-Use-mini-services-and-disable-starting-unneed.patch
+++ b/frameworks/native/0001-hybris-Use-mini-services-and-disable-starting-unneed.patch
@@ -1,7 +1,7 @@
-From c4beef9773e328f1533d65bf08677d189b2b85c9 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Thu, 13 Jul 2017 00:53:55 +0300
-Subject: [PATCH 1/3] (hybris) Use mini services and disable starting unneeded
+Subject: [PATCH] (hybris) Use mini services and disable starting unneeded
  services.
 
 Change-Id: I6e80eb3e2d92ddfbd83f1933971c3f24e9570d28
@@ -10,7 +10,7 @@ Change-Id: I6e80eb3e2d92ddfbd83f1933971c3f24e9570d28
  1 file changed, 26 insertions(+), 10 deletions(-)
 
 diff --git a/cmds/servicemanager/servicemanager.rc b/cmds/servicemanager/servicemanager.rc
-index 152ac28ba..1f447f9b0 100644
+index 152ac28ba48bc068a154fac1dc7b873d0e66739b..1f447f9b085886e68411a515812823a5094e28ad 100644
 --- a/cmds/servicemanager/servicemanager.rc
 +++ b/cmds/servicemanager/servicemanager.rc
 @@ -4,15 +4,31 @@ service servicemanager /system/bin/servicemanager
@@ -55,6 +55,3 @@ index 152ac28ba..1f447f9b0 100644
 +    class main
 +    user system
 +    group audio
--- 
-2.23.0
-

--- a/frameworks/native/0002-hybris-Pick-GLES-shared-objects-from-appropriate-pat.patch
+++ b/frameworks/native/0002-hybris-Pick-GLES-shared-objects-from-appropriate-pat.patch
@@ -1,7 +1,7 @@
-From c47e6721089fb0773f4cf93b880746b01bdf2ded Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Wed, 15 Jul 2015 08:29:08 +0000
-Subject: [PATCH 2/3] (hybris) Pick GLES shared objects from appropriate paths
+Subject: [PATCH] (hybris) Pick GLES shared objects from appropriate paths
  (32-bit case)
 
 Change-Id: I4c7739ba8a4d64fa115163d5700b0df3370b286b
@@ -11,7 +11,7 @@ Signed-off-by: Simonas Leleiva <simonas.leleiva@jollamobile.com>
  1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/opengl/libs/EGL/Loader.cpp b/opengl/libs/EGL/Loader.cpp
-index 038a43233..426b9d7de 100644
+index 038a43233774a48797b19d62ba701daf4b5b15bd..426b9d7de5f94475c9b7bad7841a5b511adf6d54 100644
 --- a/opengl/libs/EGL/Loader.cpp
 +++ b/opengl/libs/EGL/Loader.cpp
 @@ -140,9 +140,9 @@ static void* load_wrapper(const char* path) {
@@ -43,6 +43,3 @@ index 038a43233..426b9d7de 100644
      }
  
      if (!cnx->libEgl || !cnx->libGles2 || !cnx->libGles1) {
--- 
-2.23.0
-

--- a/frameworks/native/0003-hybris-Use-private-__get_tls_hooks-from-bionic.patch
+++ b/frameworks/native/0003-hybris-Use-private-__get_tls_hooks-from-bionic.patch
@@ -1,7 +1,7 @@
-From 7b53411f90d79f206d1a1a689b36f87f750fd301 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david.greaves@jollamobile.com>
 Date: Tue, 25 Nov 2014 14:55:27 +0100
-Subject: [PATCH 3/3] (hybris) Use private __get_tls_hooks from bionic
+Subject: [PATCH] (hybris) Use private __get_tls_hooks from bionic
 
 Change-Id: I38a4ea6d8561ab7da5dfedeeba16b84ee493051e
 Signed-off-by: David Greaves <david.greaves@jollamobile.com>
@@ -11,7 +11,7 @@ Signed-off-by: David Greaves <david.greaves@jollamobile.com>
  2 files changed, 3 insertions(+), 11 deletions(-)
 
 diff --git a/opengl/libs/EGL/egl.cpp b/opengl/libs/EGL/egl.cpp
-index 25b1009ba..51a5582c7 100644
+index 25b1009ba2ef762001cd088e4b126c8f775954d0..51a5582c7f3dfc75158df26779afd0581a92a9ed 100644
 --- a/opengl/libs/EGL/egl.cpp
 +++ b/opengl/libs/EGL/egl.cpp
 @@ -241,7 +241,7 @@ void gl_noop() {
@@ -24,7 +24,7 @@ index 25b1009ba..51a5582c7 100644
  }
  
 diff --git a/opengl/libs/hooks.h b/opengl/libs/hooks.h
-index 63a0e140c..9eac975f1 100644
+index 63a0e140ccc1774f91c70b8b27eb408d01109e69..9eac975f1f8ff4968c65d812c7c357e0a967bbc4 100644
 --- a/opengl/libs/hooks.h
 +++ b/opengl/libs/hooks.h
 @@ -34,7 +34,7 @@
@@ -54,6 +54,3 @@ index 63a0e140c..9eac975f1 100644
      gl_hooks_t const* hooks = tls_hooks[TLS_SLOT_OPENGL_API];
      return hooks;
  }
--- 
-2.23.0
-

--- a/frameworks/native/0004-hybris-Pick-GLES-shared-objects-from-appropriate-pat.patch
+++ b/frameworks/native/0004-hybris-Pick-GLES-shared-objects-from-appropriate-pat.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Franz-Josef Haider <franz.haider@jolla.com>
+Date: Sun, 21 Feb 2021 19:20:12 +0000
+Subject: [PATCH] (hybris) Pick GLES shared objects from appropriate paths
+ (64-bit case)
+
+Change-Id: I71ac1072e68c4d97f2808592ac007f1dc470d69f
+---
+ opengl/libs/EGL/Loader.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/opengl/libs/EGL/Loader.cpp b/opengl/libs/EGL/Loader.cpp
+index 426b9d7de5f94475c9b7bad7841a5b511adf6d54..90a30393cfea6ad2107cb0d444a55f6e64ba0e59 100644
+--- a/opengl/libs/EGL/Loader.cpp
++++ b/opengl/libs/EGL/Loader.cpp
+@@ -140,7 +140,7 @@ static void* load_wrapper(const char* path) {
+ 
+ #ifndef EGL_WRAPPER_DIR
+ #if defined(__LP64__)
+-#define EGL_WRAPPER_DIR "/system/lib64/"
++#define EGL_WRAPPER_DIR ""
+ #else
+ #define EGL_WRAPPER_DIR ""
+ #endif

--- a/hardware/libhardware/0001-hybris-Add-aapcs-float-handling-to-audio-api-headers.patch
+++ b/hardware/libhardware/0001-hybris-Add-aapcs-float-handling-to-audio-api-headers.patch
@@ -1,7 +1,7 @@
-From d90de882771f1a2b1c4730a668f00a6897b11f1f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Siteshwar Vashisht <siteshwar@gmail.com>
 Date: Wed, 21 May 2014 01:23:45 +0530
-Subject: [PATCH 1/3] (hybris) Add aapcs float handling to audio api headers
+Subject: [PATCH] (hybris) Add aapcs float handling to audio api headers
 
 Change-Id: I2b0015aa75e1afa849a5563fa92d041c37f88780
 ---
@@ -9,7 +9,7 @@ Change-Id: I2b0015aa75e1afa849a5563fa92d041c37f88780
  1 file changed, 11 insertions(+), 5 deletions(-)
 
 diff --git a/include/hardware/audio.h b/include/hardware/audio.h
-index feebd23e..c0f56c5d 100644
+index feebd23e06764667a747b46a42cba872fb8a8985..c0f56c5d557d1849fa4f76c353f826ad3a691ee6 100644
 --- a/include/hardware/audio.h
 +++ b/include/hardware/audio.h
 @@ -30,6 +30,12 @@
@@ -69,6 +69,3 @@ index feebd23e..c0f56c5d 100644
  
      /**
       * set_mode is called when the audio mode changes. AUDIO_MODE_NORMAL mode
--- 
-2.23.0
-

--- a/hardware/libhardware/0002-hybris-Search-for-libraries-first-from-usr-libexec-d.patch
+++ b/hardware/libhardware/0002-hybris-Search-for-libraries-first-from-usr-libexec-d.patch
@@ -1,7 +1,7 @@
-From 926be8f94140a3f2b966c1d5a3465729c0065982 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Matti Lehtimaki <matti.lehtimaki@gmail.com>
 Date: Wed, 5 Aug 2015 14:31:01 +0200
-Subject: [PATCH 2/3] (hybris) Search for libraries first from
+Subject: [PATCH] (hybris) Search for libraries first from
  /usr/libexec/droid-hybris/system/lib/hw/.
 
 Change-Id: I7496d961f8218b6077b9d628dd350ac20550b5d2
@@ -10,7 +10,7 @@ Change-Id: I7496d961f8218b6077b9d628dd350ac20550b5d2
  1 file changed, 7 insertions(+)
 
 diff --git a/hardware.c b/hardware.c
-index 6e72ce9f..ecdcf879 100644
+index 6e72ce9f344544a1d3f05792abd499711f8681d6..ecdcf87970d3c5cfaaa717deec4d83b03caa0746 100644
 --- a/hardware.c
 +++ b/hardware.c
 @@ -39,10 +39,12 @@
@@ -38,6 +38,3 @@ index 6e72ce9f..ecdcf879 100644
      snprintf(path, path_len, "%s/%s.%s.so",
               HAL_LIBRARY_PATH3, name, subname);
      if (path_in_path(path, HAL_LIBRARY_PATH3) && access(path, R_OK) == 0)
--- 
-2.23.0
-

--- a/hardware/libhardware/0003-hybris-gps.h-Use-proper-aapcs-attribute-with-functio.patch
+++ b/hardware/libhardware/0003-hybris-gps.h-Use-proper-aapcs-attribute-with-functio.patch
@@ -1,15 +1,15 @@
-From d08e91a3fa638fb67e1cac715583dac1d8d67f4e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jollamobile.com>
 Date: Tue, 30 Jan 2018 14:55:33 +0200
-Subject: [PATCH 3/3] (hybris) gps.h Use proper aapcs attribute with functions
- with float arguments
+Subject: [PATCH] (hybris) gps.h Use proper aapcs attribute with functions with
+ float arguments
 
 ---
  include/hardware/gps.h | 10 ++++++++--
  1 file changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/include/hardware/gps.h b/include/hardware/gps.h
-index 4e108b3f..e461aa1d 100644
+index 4e108b3f230d88283e5d309b960e86a1aca48f6d..e461aa1d8ca7771d808772973962a77a171c7c37 100644
 --- a/include/hardware/gps.h
 +++ b/include/hardware/gps.h
 @@ -28,6 +28,12 @@
@@ -43,6 +43,3 @@ index 4e108b3f..e461aa1d 100644
  
     /**
      * Pause monitoring a particular geofence.
--- 
-2.23.0
-

--- a/system/core/0001-hybris-Add-usr-libexec-droid-hybris-lib-dev-alog-to-.patch
+++ b/system/core/0001-hybris-Add-usr-libexec-droid-hybris-lib-dev-alog-to-.patch
@@ -1,9 +1,8 @@
-From dd85495ff6a3e963d5624af0503bd741dcfd714b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 6 Nov 2013 21:09:30 +0000
-Subject: [PATCH 01/50] (hybris) Add /usr/libexec/droid-hybris/lib-dev-alog/ to
- the LD_LIBRARY_PATH for all init'ed binaries to support the /dev/alog used in
- Mer
+Subject: [PATCH] (hybris) Add /usr/libexec/droid-hybris/lib-dev-alog/ to the
+ LD_LIBRARY_PATH for all init'ed binaries to support the /dev/alog used in Mer
 
 Change-Id: If58b8bd7c52b71e6e1f86f714142890dc8c73fd8
 ---
@@ -11,7 +10,7 @@ Change-Id: If58b8bd7c52b71e6e1f86f714142890dc8c73fd8
  1 file changed, 3 insertions(+)
 
 diff --git a/rootdir/init.environ.rc.in b/rootdir/init.environ.rc.in
-index 455c9a8e3..0abd169df 100644
+index 455c9a8e3e890f88dbd361a21b524f074f0a3f85..0abd169dfd403af5f02dc8474492bd12af3ea8f3 100644
 --- a/rootdir/init.environ.rc.in
 +++ b/rootdir/init.environ.rc.in
 @@ -1,5 +1,8 @@
@@ -23,6 +22,3 @@ index 455c9a8e3..0abd169df 100644
      export ANDROID_BOOTLOGO 1
      export ANDROID_ROOT /system
      export ANDROID_ASSETS /system/app
--- 
-2.23.0
-

--- a/system/core/0002-hybris-Don-t-create-mount-dev-proc-sys.-when-booting.patch
+++ b/system/core/0002-hybris-Don-t-create-mount-dev-proc-sys.-when-booting.patch
@@ -1,8 +1,8 @@
-From 6809c295f880556decb5a7342209bb0094cf541d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 8 Oct 2013 16:59:30 +0100
-Subject: [PATCH 02/50] (hybris) Don't create/mount dev/proc/sys... when
- booting with Mer
+Subject: [PATCH] (hybris) Don't create/mount dev/proc/sys... when booting with
+ Mer
 
 Change-Id: I16afd5bf56ee3e36f09b3496b80e356ce9269a64
 ---
@@ -10,7 +10,7 @@ Change-Id: I16afd5bf56ee3e36f09b3496b80e356ce9269a64
  1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/init/first_stage_init.cpp b/init/first_stage_init.cpp
-index 2b899408a..998374a84 100644
+index 2b899408a7d6fe3173b946c015bf36a3ca3645a6..998374a8401eee4b8c22dd71dd4d5425b2d781de 100644
 --- a/init/first_stage_init.cpp
 +++ b/init/first_stage_init.cpp
 @@ -117,18 +117,18 @@ int FirstStageMain(int argc, char** argv) {
@@ -37,6 +37,3 @@ index 2b899408a..998374a84 100644
      CHECKCALL(mount("selinuxfs", "/sys/fs/selinux", "selinuxfs", 0, NULL));
  
      CHECKCALL(mknod("/dev/kmsg", S_IFCHR | 0600, makedev(1, 11)));
--- 
-2.23.0
-

--- a/system/core/0003-hybris-Mer-can-specify-mis-alignment-handling-this-i.patch
+++ b/system/core/0003-hybris-Mer-can-specify-mis-alignment-handling-this-i.patch
@@ -1,8 +1,8 @@
-From 30530bd1e6823e6942dfef06e7909b68cf22fd1d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:07:56 +0100
-Subject: [PATCH 03/50] (hybris) Mer can specify mis-alignment handling - this
- is the wrong place to set it
+Subject: [PATCH] (hybris) Mer can specify mis-alignment handling - this is the
+ wrong place to set it
 
 Change-Id: Ib46c0a0b6d285dbcd05736e7ba9e9fd0a0480984
 ---
@@ -10,7 +10,7 @@ Change-Id: Ib46c0a0b6d285dbcd05736e7ba9e9fd0a0480984
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index e898d4dc9..3ae5e1944 100644
+index e898d4dc975e7065ec5c9f6876346938a1a637a0..3ae5e19443030dc38a93db477a0b8c2f5dd73802 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -129,13 +129,15 @@ on init
@@ -30,6 +30,3 @@ index e898d4dc9..3ae5e1944 100644
      write /proc/sys/kernel/sched_latency_ns 10000000
      write /proc/sys/kernel/sched_wakeup_granularity_ns 2000000
      write /proc/sys/kernel/sched_child_runs_first 0
--- 
-2.23.0
-

--- a/system/core/0004-hybris-Mount-points-are-handled-by-Mer.patch
+++ b/system/core/0004-hybris-Mount-points-are-handled-by-Mer.patch
@@ -1,7 +1,7 @@
-From 79f69b9aa4cdda9f9077b4b1cda024d7dfad37db Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:09:20 +0100
-Subject: [PATCH 04/50] (hybris) Mount points are handled by Mer
+Subject: [PATCH] (hybris) Mount points are handled by Mer
 
 Change-Id: I295b30a47b6e147b037275032a00b304085fe711
 ---
@@ -9,7 +9,7 @@ Change-Id: I295b30a47b6e147b037275032a00b304085fe711
  1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 3ae5e1944..897d392dc 100644
+index 3ae5e19443030dc38a93db477a0b8c2f5dd73802..897d392dcc38c7a36673f46ba70e734a74148a4d 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -50,8 +50,8 @@ on init
@@ -37,6 +37,3 @@ index 3ae5e1944..897d392dc 100644
  
      # Make sure /sys/kernel/debug (if present) is labeled properly
      # Note that tracefs may be mounted under debug, so we need to cross filesystems
--- 
-2.23.0
-

--- a/system/core/0005-hybris-Systemd-handles-control-groups.patch
+++ b/system/core/0005-hybris-Systemd-handles-control-groups.patch
@@ -1,7 +1,7 @@
-From b6eb51f135773ee68fe490fbf366d54bddb0515d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:10:16 +0100
-Subject: [PATCH 05/50] (hybris) Systemd handles control groups
+Subject: [PATCH] (hybris) Systemd handles control groups
 
 Change-Id: I92ef4b2389544906be32169c57176575eb1719ec
 ---
@@ -9,7 +9,7 @@ Change-Id: I92ef4b2389544906be32169c57176575eb1719ec
  1 file changed, 8 deletions(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 897d392dc..10d11146a 100644
+index 897d392dcc38c7a36673f46ba70e734a74148a4d..10d11146a465e70dfb6bbde9f550b66b647bee46 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -24,14 +24,6 @@ on early-init
@@ -27,6 +27,3 @@ index 897d392dc..10d11146a 100644
      start ueventd
  
      # Run apexd-bootstrap so that APEXes that provide critical libraries
--- 
-2.23.0
-

--- a/system/core/0006-hybris-Mer-uses-udev.patch
+++ b/system/core/0006-hybris-Mer-uses-udev.patch
@@ -1,7 +1,7 @@
-From 0133e7aff942108fcbd57f228775ec253b0158f5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Tue, 22 Oct 2013 17:12:18 +0100
-Subject: [PATCH 06/50] (hybris) Mer uses udev
+Subject: [PATCH] (hybris) Mer uses udev
 
 Change-Id: I7588a80db2c77879fb56d5decfd055224f20ab54
 ---
@@ -9,7 +9,7 @@ Change-Id: I7588a80db2c77879fb56d5decfd055224f20ab54
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 10d11146a..02c89ffca 100644
+index 10d11146a465e70dfb6bbde9f550b66b647bee46..02c89ffca45c522a814e775274b8910a0e823b79 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -24,7 +24,7 @@ on early-init
@@ -21,6 +21,3 @@ index 10d11146a..02c89ffca 100644
  
      # Run apexd-bootstrap so that APEXes that provide critical libraries
      # become available. Note that this is executed as exec_start to ensure that
--- 
-2.23.0
-

--- a/system/core/0007-hybris-Add-a-ready-trigger-to-init-to-run-post-boot.patch
+++ b/system/core/0007-hybris-Add-a-ready-trigger-to-init-to-run-post-boot.patch
@@ -1,7 +1,7 @@
-From 37942533d3a2ef0d0931260359d758131da31eba Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 20 Nov 2013 19:18:51 +0000
-Subject: [PATCH 07/50] (hybris) Add a ready trigger to init to run post boot
+Subject: [PATCH] (hybris) Add a ready trigger to init to run post boot
 
 Change-Id: I9c828463424c0e82c3de0159db08299e7ce6fe06
 ---
@@ -9,7 +9,7 @@ Change-Id: I9c828463424c0e82c3de0159db08299e7ce6fe06
  1 file changed, 6 insertions(+)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index 6b03bc94d..c3a634bc8 100644
+index 6b03bc94d6c70f92917e224e1b71650ba81c445c..c3a634bc8dd280c5ecc118723fafb8fc17a5137a 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
 @@ -762,6 +762,12 @@ int SecondStageMain(int argc, char** argv) {
@@ -25,6 +25,3 @@ index 6b03bc94d..c3a634bc8 100644
      while (true) {
          // By default, sleep until something happens.
          auto epoll_timeout = std::optional<std::chrono::milliseconds>{};
--- 
-2.23.0
-

--- a/system/core/0008-hybris-Notify-Mer-s-systemd-that-we-re-done.patch
+++ b/system/core/0008-hybris-Notify-Mer-s-systemd-that-we-re-done.patch
@@ -1,7 +1,7 @@
-From 13a9255e20f0dc85eaba455b308766890c9ea688 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 20 Nov 2013 19:24:31 +0000
-Subject: [PATCH 08/50] (hybris) Notify Mer's systemd that we're done
+Subject: [PATCH] (hybris) Notify Mer's systemd that we're done
 
 Change-Id: If6a16f43397f00c8e579af79ae6cf8459786e7b3
 Signed-off-by: David Greaves <david.greaves@jollamobile.com>
@@ -10,7 +10,7 @@ Signed-off-by: David Greaves <david.greaves@jollamobile.com>
  1 file changed, 16 insertions(+)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 02c89ffca..8df3c1f17 100644
+index 02c89ffca45c522a814e775274b8910a0e823b79..8df3c1f171ae1db0afc09d63188b1558179109af 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -851,3 +851,19 @@ on property:ro.debuggable=1
@@ -33,6 +33,3 @@ index 02c89ffca..8df3c1f17 100644
 +on property:persist.sys.recovery_update=true
 +    start flash_recovery
 +
--- 
-2.23.0
-

--- a/system/core/0009-hybris-Disable-usb-import.patch
+++ b/system/core/0009-hybris-Disable-usb-import.patch
@@ -1,7 +1,7 @@
-From c94660fa0cbbd9411a60973ef27efc6f67c5da31 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Greaves <david@dgreaves.com>
 Date: Wed, 19 Feb 2014 19:02:32 +0000
-Subject: [PATCH 09/50] (hybris) Disable usb import
+Subject: [PATCH] (hybris) Disable usb import
 
 Change-Id: I8aba60bc79fb4aab3854f0569b325ad69c5126d4
 Signed-off-by: David Greaves <david@dgreaves.com>
@@ -10,7 +10,7 @@ Signed-off-by: David Greaves <david@dgreaves.com>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 8df3c1f17..1fb018783 100644
+index 8df3c1f171ae1db0afc09d63188b1558179109af..1fb018783089c7a0d226f204df67e4df2f7362f8 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -5,7 +5,8 @@
@@ -23,6 +23,3 @@ index 8df3c1f17..1fb018783 100644
  import /init.${ro.hardware}.rc
  import /vendor/etc/init/hw/init.${ro.hardware}.rc
  import /init.usb.configfs.rc
--- 
-2.23.0
-

--- a/system/core/0010-hybris-allow-system-group-to-trigger-haptics.patch
+++ b/system/core/0010-hybris-allow-system-group-to-trigger-haptics.patch
@@ -1,7 +1,7 @@
-From 59de5609b0aa2dc83ba2315c2c78270c40f2ff60 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Thu, 13 Mar 2014 08:51:53 +0000
-Subject: [PATCH 10/50] (hybris) allow system group to trigger haptics
+Subject: [PATCH] (hybris) allow system group to trigger haptics
 
 Signed-off-by: Simonas Leleiva <simonas.leleiva@jollamobile.com>
 
@@ -14,7 +14,7 @@ Change-Id: I9f1af094fa8a4ef48f4c3ea0ec35cb66d3c083d8
  1 file changed, 3 insertions(+)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 1fb018783..37a1174d9 100644
+index 1fb018783089c7a0d226f204df67e4df2f7362f8..37a1174d97cacaa3812198b817c391c309bafaec 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -750,6 +750,9 @@ on boot
@@ -27,6 +27,3 @@ index 1fb018783..37a1174d9 100644
      # Start standard binderized HAL daemons
      class_start hal
  
--- 
-2.23.0
-

--- a/system/core/0011-hybris-trigger-late_start-on-property-change.patch
+++ b/system/core/0011-hybris-trigger-late_start-on-property-change.patch
@@ -1,7 +1,7 @@
-From 6fd475a458ca4d3c51dfd1b231809a3786103e91 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Tue, 18 Mar 2014 14:07:11 +0000
-Subject: [PATCH 11/50] (hybris) trigger late_start on property change
+Subject: [PATCH] (hybris) trigger late_start on property change
 
 Android's late_start is triggered by mount_all, which also determines whether
 the /data partition is encrypted.
@@ -20,7 +20,7 @@ Conflicts:
  1 file changed, 5 insertions(+)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 37a1174d9..c104d72d5 100644
+index 37a1174d97cacaa3812198b817c391c309bafaec..c104d72d5514257aa42ee7da987fcc71ae1b99e7 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -758,6 +758,7 @@ on boot
@@ -42,6 +42,3 @@ index 37a1174d9..c104d72d5 100644
  on charger
      class_start charger
  
--- 
-2.23.0
-

--- a/system/core/0012-hybris-property_service.c-adding-support-for-getprop.patch
+++ b/system/core/0012-hybris-property_service.c-adding-support-for-getprop.patch
@@ -1,8 +1,8 @@
-From b012.23.024a0bb38d2ac30f696a9a2061bf99db Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
 Date: Thu, 31 Oct 2013 12:19:19 +0200
-Subject: [PATCH 12/50] (hybris) property_service.c: adding support for getprop
- and listprop
+Subject: [PATCH] (hybris) property_service.c: adding support for getprop and
+ listprop
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -23,7 +23,7 @@ Conflicts:
  2 files changed, 36 insertions(+), 1 deletion(-)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index c3a634bc8..c11cdf987 100644
+index c3a634bc8dd280c5ecc118723fafb8fc17a5137a..c11cdf9872470bdff75e9fbddedcf95de7f65672 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
 @@ -763,7 +763,7 @@ int SecondStageMain(int argc, char** argv) {
@@ -36,7 +36,7 @@ index c3a634bc8..c11cdf987 100644
      /* Run actions when all boot up is done and init is ready */
      am.QueueEventTrigger("ready");
 diff --git a/init/property_service.cpp b/init/property_service.cpp
-index f2c7462ab..9821a506c 100644
+index f2c7462abf027d045593d4fa6b70acc64ba51fd2..9821a506c51dbff6a967028de29fb6658cf9c454 100644
 --- a/init/property_service.cpp
 +++ b/init/property_service.cpp
 @@ -516,6 +516,9 @@ uint32_t HandlePropertySet(const std::string& name, const std::string& value,
@@ -89,6 +89,3 @@ index f2c7462ab..9821a506c 100644
      default:
          LOG(ERROR) << "sys_prop: invalid command " << cmd;
          socket.SendUint32(PROP_ERROR_INVALID_CMD);
--- 
-2.23.0
-

--- a/system/core/0013-hybris-reach-main-init-state.patch
+++ b/system/core/0013-hybris-reach-main-init-state.patch
@@ -1,7 +1,7 @@
-From e9af320c091fa528c32a29e4b74b282d86ef0847 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Sat, 22 Aug 2015 12:03:42 +0100
-Subject: [PATCH 13/50] (hybris) reach main init state
+Subject: [PATCH] (hybris) reach main init state
 
 Change-Id: I471f48afaebf91c92f0d2a7bd3a24c5d1fa58ecd
 ---
@@ -9,7 +9,7 @@ Change-Id: I471f48afaebf91c92f0d2a7bd3a24c5d1fa58ecd
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index c104d72d5..2e9d1b736 100644
+index c104d72d5514257aa42ee7da987fcc71ae1b99e7..2e9d1b736ca33f07d7dac5382c271c3b5cc5aaf6 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -342,7 +342,7 @@ on late-init
@@ -39,6 +39,3 @@ index c104d72d5..2e9d1b736 100644
      installkey /data
  
      # Start bootcharting as soon as possible after the data partition is
--- 
-2.23.0
-

--- a/system/core/0014-hybris-Disable-setting-hostname-and-domainname-in-in.patch
+++ b/system/core/0014-hybris-Disable-setting-hostname-and-domainname-in-in.patch
@@ -1,8 +1,7 @@
-From 3642f27d982b64ba2c382ea1e1e15a89730ede56 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Sat, 6 Aug 2016 11:37:38 +0300
-Subject: [PATCH 14/50] (hybris) Disable setting hostname and domainname in
- init.rc.
+Subject: [PATCH] (hybris) Disable setting hostname and domainname in init.rc.
 
 Change-Id: I5b9f59e80760e53636763c89f8f76f350c17b3ec
 ---
@@ -10,7 +9,7 @@ Change-Id: I5b9f59e80760e53636763c89f8f76f350c17b3ec
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 2e9d1b736..8b635876c 100644
+index 2e9d1b736ca33f07d7dac5382c271c3b5cc5aaf6..8b635876c30d9ebcf9c42421796789d0883ad684 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -646,8 +646,9 @@ on zygote-start && property:ro.crypto.state=encrypted && property:ro.crypto.type
@@ -25,6 +24,3 @@ index 2e9d1b736..8b635876c 100644
  
      # IPsec SA default expiration length
      write /proc/sys/net/core/xfrm_acq_expires 3600
--- 
-2.23.0
-

--- a/system/core/0015-hybris-Update-rootdir-for-64bit-libs.patch
+++ b/system/core/0015-hybris-Update-rootdir-for-64bit-libs.patch
@@ -1,7 +1,7 @@
-From 51acad44e8ae673dcdde66da5980a1bdce9d3ab0 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Martin Ghosal <Martin.Ghosal@sky.uk>
 Date: Sat, 15 Oct 2016 15:38:47 +0100
-Subject: [PATCH 15/50] (hybris) Update rootdir for 64bit libs
+Subject: [PATCH] (hybris) Update rootdir for 64bit libs
 
 Change-Id: I593ae40da755c116bb28c96dcace863e6b30b4cc
 ---
@@ -9,7 +9,7 @@ Change-Id: I593ae40da755c116bb28c96dcace863e6b30b4cc
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/rootdir/init.environ.rc.in b/rootdir/init.environ.rc.in
-index 0abd169df..2194fea86 100644
+index 0abd169dfd403af5f02dc8474492bd12af3ea8f3..2194fea864ce500408e892bea4e6b68a5fd45c01 100644
 --- a/rootdir/init.environ.rc.in
 +++ b/rootdir/init.environ.rc.in
 @@ -1,8 +1,8 @@
@@ -23,6 +23,3 @@ index 0abd169df..2194fea86 100644
      export ANDROID_BOOTLOGO 1
      export ANDROID_ROOT /system
      export ANDROID_ASSETS /system/app
--- 
-2.23.0
-

--- a/system/core/0016-hybris-Disable-all-zygote-variations.patch
+++ b/system/core/0016-hybris-Disable-all-zygote-variations.patch
@@ -1,7 +1,7 @@
-From 0da90c161feb77a57cd82e33813894610b7444a9 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Martin Ghosal <Martin.Ghosal@sky.uk>
 Date: Sun, 8 Jan 2017 16:34:54 +0000
-Subject: [PATCH 16/50] (hybris) Disable all zygote variations
+Subject: [PATCH] (hybris) Disable all zygote variations
 
 Change-Id: Ie1ad26486f47b3bf67134db917b3c9e51536904c
 ---
@@ -12,7 +12,7 @@ Change-Id: Ie1ad26486f47b3bf67134db917b3c9e51536904c
  4 files changed, 6 insertions(+)
 
 diff --git a/rootdir/init.zygote32.rc b/rootdir/init.zygote32.rc
-index bf3fb4217..1e2062bec 100644
+index bf3fb4217365865948a25c1f7d3d974cc8b3cdd5..1e2062bec9d345db925b582ac1c23e709d57494c 100644
 --- a/rootdir/init.zygote32.rc
 +++ b/rootdir/init.zygote32.rc
 @@ -13,3 +13,4 @@ service zygote /system/bin/app_process -Xzygote /system/bin --zygote --start-sys
@@ -22,7 +22,7 @@ index bf3fb4217..1e2062bec 100644
 +    disabled
 \ No newline at end of file
 diff --git a/rootdir/init.zygote32_64.rc b/rootdir/init.zygote32_64.rc
-index 1bab588c4..108524425 100644
+index 1bab588c4cfdf4e63c91c756f566c3cdf79402a0..1085244255d896a253ef7fb5850ca17a202f612b 100644
 --- a/rootdir/init.zygote32_64.rc
 +++ b/rootdir/init.zygote32_64.rc
 @@ -13,6 +13,7 @@ service zygote /system/bin/app_process32 -Xzygote /system/bin --zygote --start-s
@@ -39,7 +39,7 @@ index 1bab588c4..108524425 100644
      writepid /dev/cpuset/foreground/tasks
 +    disabled
 diff --git a/rootdir/init.zygote64.rc b/rootdir/init.zygote64.rc
-index 6fa210a7b..c7c5b196f 100644
+index 6fa210a7b858249b70879a1c6d30aca9799e89a0..c7c5b196f8c9f853ec3ec5b6cd201a8839d6b8df 100644
 --- a/rootdir/init.zygote64.rc
 +++ b/rootdir/init.zygote64.rc
 @@ -13,3 +13,4 @@ service zygote /system/bin/app_process64 -Xzygote /system/bin --zygote --start-s
@@ -48,7 +48,7 @@ index 6fa210a7b..c7c5b196f 100644
      writepid /dev/cpuset/foreground/tasks
 +    disabled
 diff --git a/rootdir/init.zygote64_32.rc b/rootdir/init.zygote64_32.rc
-index 48461ecd3..7a8e6ea5d 100644
+index 48461ecd3f8985a8a8bb8cf3b5637df7709c850b..7a8e6ea5d866b4dac9a60c90d21ff7e7f2479bd6 100644
 --- a/rootdir/init.zygote64_32.rc
 +++ b/rootdir/init.zygote64_32.rc
 @@ -13,6 +13,7 @@ service zygote /system/bin/app_process64 -Xzygote /system/bin --zygote --start-s
@@ -64,6 +64,3 @@ index 48461ecd3..7a8e6ea5d 100644
      onrestart restart zygote
      writepid /dev/cpuset/foreground/tasks
 +    disabled
--- 
-2.23.0
-

--- a/system/core/0017-hybris-Disable-ueventd-service.patch
+++ b/system/core/0017-hybris-Disable-ueventd-service.patch
@@ -1,7 +1,7 @@
-From 19472a4180ff9d75a919fa0cc626bc59d77936c8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Martin Ghosal <Martin.Ghosal@sky.uk>
 Date: Sun, 8 Jan 2017 17:16:08 +0000
-Subject: [PATCH 17/50] (hybris) Disable ueventd service
+Subject: [PATCH] (hybris) Disable ueventd service
 
 Change-Id: I8ee7b863a533f4a6ef7658ef1c1ef4bdb95d5d65
 ---
@@ -9,7 +9,7 @@ Change-Id: I8ee7b863a533f4a6ef7658ef1c1ef4bdb95d5d65
  1 file changed, 2 insertions(+)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 8b635876c..c66608d9c 100644
+index 8b635876c30d9ebcf9c42421796789d0883ad684..c66608d9c8849fb85c1c4133f4b28d79e7da1e3b 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -842,6 +842,8 @@ service ueventd /system/bin/ueventd
@@ -21,6 +21,3 @@ index 8b635876c..c66608d9c 100644
  
  service console /system/bin/sh
      class core
--- 
-2.23.0
-

--- a/system/core/0018-hybris-Disable-SELinux.patch
+++ b/system/core/0018-hybris-Disable-SELinux.patch
@@ -1,7 +1,7 @@
-From 530e84916fc5a241395dd6ce75afb1b58935e0fb Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Thu, 9 Feb 2017 21:48:19 +0200
-Subject: [PATCH 18/50] (hybris) Disable SELinux
+Subject: [PATCH] (hybris) Disable SELinux
 
 Change-Id: I0511b2a0de1b20996f4fb8e9f3569acb41e2cf0f
 ---
@@ -11,7 +11,7 @@ Change-Id: I0511b2a0de1b20996f4fb8e9f3569acb41e2cf0f
  3 files changed, 17 insertions(+), 1 deletion(-)
 
 diff --git a/init/property_service.cpp b/init/property_service.cpp
-index 9821a506c..d13f3429c 100644
+index 9821a506c51dbff6a967028de29fb6658cf9c454..d13f3429cd51eb74638d49e5a161bfd14a29d733 100644
 --- a/init/property_service.cpp
 +++ b/init/property_service.cpp
 @@ -128,6 +128,8 @@ bool CanReadProperty(const std::string& source_context, const std::string& name)
@@ -24,7 +24,7 @@ index 9821a506c..d13f3429c 100644
          return false;
      }
 diff --git a/init/selinux.cpp b/init/selinux.cpp
-index 86238b430..a47baebfe 100644
+index 86238b430376889c28bf87b2bea19c9cf9f06ed8..a47baebfe3e4981cbbd8d5805f63d84ca1c56b48 100644
 --- a/init/selinux.cpp
 +++ b/init/selinux.cpp
 @@ -421,6 +421,9 @@ bool LoadPolicy() {
@@ -38,7 +38,7 @@ index 86238b430..a47baebfe 100644
  
      LOG(INFO) << "Loading SELinux policy";
 diff --git a/init/service.cpp b/init/service.cpp
-index 2db548efe..21b22aefb 100644
+index 2db548efed41603daabf9e48492dec97b20d5fda..21b22aefb33103b2b05043999795a17d8f163156 100644
 --- a/init/service.cpp
 +++ b/init/service.cpp
 @@ -70,6 +70,9 @@ using android::base::WriteStringToFile;
@@ -94,6 +94,3 @@ index 2db548efe..21b22aefb 100644
      LOG(INFO) << "starting service '" << name_ << "'...";
  
      pid_t pid = -1;
--- 
-2.23.0
-

--- a/system/core/0019-hybris-Properly-handle-shutdown-from-Mer.patch
+++ b/system/core/0019-hybris-Properly-handle-shutdown-from-Mer.patch
@@ -1,7 +1,7 @@
-From 9b688f7fc4342770c933e132a6e3b6ba4130c30d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Sat, 8 Jul 2017 00:27:20 +0300
-Subject: [PATCH 19/50] (hybris) Properly handle shutdown from Mer.
+Subject: [PATCH] (hybris) Properly handle shutdown from Mer.
 
 Change-Id: I89daebb9559d38f3c639f4634c417252c7a92fe0
 ---
@@ -9,7 +9,7 @@ Change-Id: I89daebb9559d38f3c639f4634c417252c7a92fe0
  1 file changed, 9 insertions(+)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index c66608d9c..0406dcb65 100644
+index c66608d9c8849fb85c1c4133f4b28d79e7da1e3b..0406dcb65eda979ecc38496d6c4864513a81719a 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -877,6 +877,15 @@ service droid_init_done /bin/sh /usr/bin/droid/droid-init-done.sh
@@ -28,6 +28,3 @@ index c66608d9c..0406dcb65 100644
  # update recovery if enabled
  on property:persist.sys.recovery_update=true
      start flash_recovery
--- 
-2.23.0
-

--- a/system/core/0020-hybris-Use-services-from-usr-libexec-droid-hybris-sy.patch
+++ b/system/core/0020-hybris-Use-services-from-usr-libexec-droid-hybris-sy.patch
@@ -1,7 +1,7 @@
-From 45620e6ef26f76c69119a341763e3569ba9d3f1c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Thu, 9 Feb 2017 21:57:47 +0200
-Subject: [PATCH 20/50] (hybris) Use services from
+Subject: [PATCH] (hybris) Use services from
  /usr/libexec/droid-hybris/system/etc/init/.
 
 Change-Id: I6185781c2bd6a2db281201ad705394f4d6d24131
@@ -13,7 +13,7 @@ Change-Id: I6185781c2bd6a2db281201ad705394f4d6d24131
  create mode 100644 init/init_parser.cpp
 
 diff --git a/init/init.cpp b/init/init.cpp
-index c11cdf987..74e1c3855 100644
+index c11cdf9872470bdff75e9fbddedcf95de7f65672..74e1c3855f03caaf1aebcfff317b1f900c19321d 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
 @@ -130,8 +130,8 @@ static void LoadBootScripts(ActionManager& action_manager, ServiceList& service_
@@ -29,7 +29,7 @@ index c11cdf987..74e1c3855 100644
              late_import_paths.emplace_back("/product/etc/init");
 diff --git a/init/init_parser.cpp b/init/init_parser.cpp
 new file mode 100644
-index 000000000..c4b80636a
+index 0000000000000000000000000000000000000000..c4b80636af96e2d18774fbb15a796c694f748dc7
 --- /dev/null
 +++ b/init/init_parser.cpp
 @@ -0,0 +1,169 @@
@@ -203,7 +203,7 @@ index 000000000..c4b80636a
 +}  // namespace init
 +}  // namespace android
 diff --git a/init/util.cpp b/init/util.cpp
-index 63d2d4442..82dfa05f0 100644
+index 63d2d444281104dbeca997d30b0c2fc0b3b6dc97..82dfa05f02c004e11852ddcfc7d1d8ab17745c67 100644
 --- a/init/util.cpp
 +++ b/init/util.cpp
 @@ -158,7 +158,8 @@ out_unlink:
@@ -216,6 +216,3 @@ index 63d2d4442..82dfa05f0 100644
      if (fd == -1) {
          return ErrnoError() << "open() failed";
      }
--- 
-2.23.0
-

--- a/system/core/0021-hybris-Remove-LD_LIBRARY_PATH-from-init.environ.rc.patch
+++ b/system/core/0021-hybris-Remove-LD_LIBRARY_PATH-from-init.environ.rc.patch
@@ -1,7 +1,7 @@
-From b1c8cae24979597d2db6757923b4e874df244b67 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Tue, 17 Oct 2017 21:58:40 +0300
-Subject: [PATCH 21/50] (hybris) Remove LD_LIBRARY_PATH from init.environ.rc
+Subject: [PATCH] (hybris) Remove LD_LIBRARY_PATH from init.environ.rc
 
 Change-Id: I52a2c733f609f90b6ac31be72a4f8fe7681beac0
 ---
@@ -9,7 +9,7 @@ Change-Id: I52a2c733f609f90b6ac31be72a4f8fe7681beac0
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/rootdir/init.environ.rc.in b/rootdir/init.environ.rc.in
-index 2194fea86..8bcad40e2 100644
+index 2194fea864ce500408e892bea4e6b68a5fd45c01..8bcad40e20181527f45e5278b0fdc47ca356bdd6 100644
 --- a/rootdir/init.environ.rc.in
 +++ b/rootdir/init.environ.rc.in
 @@ -1,8 +1,8 @@
@@ -23,6 +23,3 @@ index 2194fea86..8bcad40e2 100644
      export ANDROID_BOOTLOGO 1
      export ANDROID_ROOT /system
      export ANDROID_ASSETS /system/app
--- 
-2.23.0
-

--- a/system/core/0022-hybris-define-32-bit-LD_LIBRARY_PATH-for-32-bit-devi.patch
+++ b/system/core/0022-hybris-define-32-bit-LD_LIBRARY_PATH-for-32-bit-devi.patch
@@ -1,8 +1,7 @@
-From 6ab44dda7269ac17b84712d80bf3f19cf2ba2487 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jollamobile.com>
 Date: Wed, 25 Oct 2017 14:14:59 +0300
-Subject: [PATCH 22/50] (hybris) define 32-bit LD_LIBRARY_PATH for 32-bit
- devices
+Subject: [PATCH] (hybris) define 32-bit LD_LIBRARY_PATH for 32-bit devices
 
 ---
  rootdir/Android.mk                   | 13 ++++++++++++-
@@ -13,7 +12,7 @@ Subject: [PATCH 22/50] (hybris) define 32-bit LD_LIBRARY_PATH for 32-bit
  create mode 100644 rootdir/init.extraenv.armeabi-v7a.rc
 
 diff --git a/rootdir/Android.mk b/rootdir/Android.mk
-index 24b39991a..e603d2c34 100644
+index 24b39991aa6923e45ed0a2f37270f34234eeebfa..e603d2c3490b6291764908ba9b60661e132acfa0 100644
 --- a/rootdir/Android.mk
 +++ b/rootdir/Android.mk
 @@ -8,7 +8,18 @@ LOCAL_MODULE := init.rc
@@ -37,7 +36,7 @@ index 24b39991a..e603d2c34 100644
  # The init symlink must be a post install command of a file that is to TARGET_ROOT_OUT.
  # Since init.rc is required for init and satisfies that requirement, we hijack it to create the symlink.
 diff --git a/rootdir/init.environ.rc.in b/rootdir/init.environ.rc.in
-index 8bcad40e2..73fbaa413 100644
+index 8bcad40e20181527f45e5278b0fdc47ca356bdd6..73fbaa4133cecf6bf8ab85bfbc67638433c5c910 100644
 --- a/rootdir/init.environ.rc.in
 +++ b/rootdir/init.environ.rc.in
 @@ -2,6 +2,7 @@
@@ -50,14 +49,14 @@ index 8bcad40e2..73fbaa413 100644
      export ANDROID_ROOT /system
 diff --git a/rootdir/init.extraenv.armeabi-v7a.rc b/rootdir/init.extraenv.armeabi-v7a.rc
 new file mode 100644
-index 000000000..c96e2c65d
+index 0000000000000000000000000000000000000000..c96e2c65da45ca08ae4edb3dec42cc8c5ca00dea
 --- /dev/null
 +++ b/rootdir/init.extraenv.armeabi-v7a.rc
 @@ -0,0 +1,2 @@
 +on init
 +    export LD_LIBRARY_PATH /usr/libexec/droid-hybris/lib-dev-alog:/vendor/lib:/system/lib
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 0406dcb65..543970e46 100644
+index 0406dcb65eda979ecc38496d6c4864513a81719a..543970e46745e5eacfb0313f3e985aad4239c51a 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -4,6 +4,12 @@
@@ -73,6 +72,3 @@ index 0406dcb65..543970e46 100644
  import /init.environ.rc
  # Mer handles usb stuff
  #import /init.usb.rc
--- 
-2.23.0
-

--- a/system/core/0023-hybris-Fix-list-and-get-properties.patch
+++ b/system/core/0023-hybris-Fix-list-and-get-properties.patch
@@ -1,7 +1,7 @@
-From a075866fe514ac689a60b006c81acba930cc9a62 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Tue, 16 Jan 2018 16:18:31 +0200
-Subject: [PATCH 23/50] (hybris) Fix list and get properties.
+Subject: [PATCH] (hybris) Fix list and get properties.
 
 Change-Id: I9deb65f147e941fc5c9f91793f851440d02260e1
 ---
@@ -9,7 +9,7 @@ Change-Id: I9deb65f147e941fc5c9f91793f851440d02260e1
  1 file changed, 29 insertions(+), 3 deletions(-)
 
 diff --git a/init/property_service.cpp b/init/property_service.cpp
-index d13f3429c..b60d8d143 100644
+index d13f3429cd51eb74638d49e5a161bfd14a29d733..b60d8d143d1cf47152d9d5690a25c73d3d37f7bb 100644
 --- a/init/property_service.cpp
 +++ b/init/property_service.cpp
 @@ -284,6 +284,12 @@ uint32_t InitPropertySet(const std::string& name, const std::string& value) {
@@ -84,6 +84,3 @@ index d13f3429c..b60d8d143 100644
          }
          break;
        }
--- 
-2.23.0
-

--- a/system/core/0024-hybris-more-SELinux-disablement.patch
+++ b/system/core/0024-hybris-more-SELinux-disablement.patch
@@ -1,7 +1,7 @@
-From 260750e58e471a94508d56b3282dc1e475ef2f40 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
 Date: Wed, 18 Apr 2018 18:49:02 +0200
-Subject: [PATCH 24/50] (hybris) more SELinux disablement
+Subject: [PATCH] (hybris) more SELinux disablement
 
 Change-Id: Ic1bc474e993f2b66ab9114e88d7ec4f718a99d5c
 Signed-off-by: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
@@ -11,7 +11,7 @@ Signed-off-by: Simonas Leleiva <simonas.leleiva@meramo.co.uk>
  2 files changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index 74e1c3855..e90365a3a 100644
+index 74e1c3855f03caaf1aebcfff317b1f900c19321d..e90365a3a36cd37d9338eedec3fc4e8d2c71d35b 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
 @@ -653,7 +653,10 @@ int SecondStageMain(int argc, char** argv) {
@@ -26,7 +26,7 @@ index 74e1c3855..e90365a3a 100644
      // Set libavb version for Framework-only OTA match in Treble build.
      const char* avb_version = getenv("INIT_AVB_VERSION");
 diff --git a/init/selinux.cpp b/init/selinux.cpp
-index a47baebfe..2fc027ba2 100644
+index a47baebfe3e4981cbbd8d5805f63d84ca1c56b48..2fc027ba201eeb1eac8d6e589194eec5a6be5beb 100644
 --- a/init/selinux.cpp
 +++ b/init/selinux.cpp
 @@ -311,7 +311,7 @@ bool LoadSplitPolicy() {
@@ -47,6 +47,3 @@ index a47baebfe..2fc027ba2 100644
      return true;
  }
  
--- 
-2.23.0
-

--- a/system/core/0025-hybris-don-t-try-to-mount-since-mer-handles-this.patch
+++ b/system/core/0025-hybris-don-t-try-to-mount-since-mer-handles-this.patch
@@ -1,7 +1,7 @@
-From 351ea2bed9126be3fd0225078f73770b54c25d81 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 4 Jun 2018 10:00:13 +0200
-Subject: [PATCH 25/50] (hybris) don't try to mount since mer handles this
+Subject: [PATCH] (hybris) don't try to mount since mer handles this
 
 Change-Id: I305ac649fd199ef11a8d88d350f1fc06171bc0ba
 ---
@@ -9,7 +9,7 @@ Change-Id: I305ac649fd199ef11a8d88d350f1fc06171bc0ba
  1 file changed, 3 insertions(+)
 
 diff --git a/init/first_stage_mount.cpp b/init/first_stage_mount.cpp
-index 3e76556ff..e522f63a8 100644
+index 3e76556ff745af4af2808f4051d74ec1cc50f57a..e522f63a8b37ffce601fca3d52cb2a29ab95da1d 100644
 --- a/init/first_stage_mount.cpp
 +++ b/init/first_stage_mount.cpp
 @@ -841,6 +841,7 @@ bool FirstStageMountVBootV2::InitAvbHandle() {
@@ -29,6 +29,3 @@ index 3e76556ff..e522f63a8 100644
  }
  
  void SetInitAvbVersionInRecovery() {
--- 
-2.23.0
-

--- a/system/core/0026-hybris-avoid-attempting-to-mount-partitions-mer-syst.patch
+++ b/system/core/0026-hybris-avoid-attempting-to-mount-partitions-mer-syst.patch
@@ -1,8 +1,8 @@
-From 1d8767d941aaf0a1b1df5768b58cbc02d8886d8e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:28:27 +0200
-Subject: [PATCH 26/50] (hybris) avoid attempting to mount partitions,
- mer/systemd handles this
+Subject: [PATCH] (hybris) avoid attempting to mount partitions, mer/systemd
+ handles this
 
 Even partitions weren't mounted by this previously it still would produce an
 error and further boot.
@@ -13,7 +13,7 @@ Change-Id: Icaea2cd8d145d8205f4a130119aedbd2720c868d
  1 file changed, 10 insertions(+), 1 deletion(-)
 
 diff --git a/init/builtins.cpp b/init/builtins.cpp
-index 25f324ce5..f98f37ed5 100644
+index 25f324ce51cb6f5a6e750f96aefdc2b9ef9703cc..f98f37ed535a18dafb1611ad9f7682c31864ea55 100644
 --- a/init/builtins.cpp
 +++ b/init/builtins.cpp
 @@ -518,6 +518,7 @@ static Result<int> handle_fstab(const std::string& fstabfile, std::function<int(
@@ -66,6 +66,3 @@ index 25f324ce5..f98f37ed5 100644
      if (queue_event) {
          /* queue_fs_event will queue event based on mount_fstab return code
           * and return processed return code*/
--- 
-2.23.0
-

--- a/system/core/0027-hybris-load-services-from-droid-hybris-as-early-as-p.patch
+++ b/system/core/0027-hybris-load-services-from-droid-hybris-as-early-as-p.patch
@@ -1,8 +1,7 @@
-From bd3f137354a9f5187c8d7df97a1ea30ae185474d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:30:01 +0200
-Subject: [PATCH 27/50] (hybris) load services from droid-hybris as early as
- possible
+Subject: [PATCH] (hybris) load services from droid-hybris as early as possible
 
 This makes sure our service definitions are loaded first and can be used to
 overwrite service definitions which are slightly different to what we need and
@@ -14,7 +13,7 @@ Change-Id: I58e86f8b3c65f46c24fc3102a859867bccb6a713
  1 file changed, 3 insertions(+)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index e90365a3a..28a2d6661 100644
+index e90365a3a36cd37d9338eedec3fc4e8d2c71d35b..28a2d6661b97e7ee0cea0030b2d53b9c351024b2 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
 @@ -133,6 +133,9 @@ static void LoadBootScripts(ActionManager& action_manager, ServiceList& service_
@@ -27,6 +26,3 @@ index e90365a3a..28a2d6661 100644
          if (!parser.ParseConfig("/product/etc/init")) {
              late_import_paths.emplace_back("/product/etc/init");
          }
--- 
-2.23.0
-

--- a/system/core/0028-hybris-disable-remnants-of-SELinux-which-currently-b.patch
+++ b/system/core/0028-hybris-disable-remnants-of-SELinux-which-currently-b.patch
@@ -1,8 +1,7 @@
-From 0183f3623835f2d95f4fd930bc9a260a4b8f7cea Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:32:06 +0200
-Subject: [PATCH 28/50] (hybris) disable remnants of SELinux which currently
- break
+Subject: [PATCH] (hybris) disable remnants of SELinux which currently break
 
 Change-Id: I252a8399c9853d993fc17d769bfbb2e4c722cfe8
 ---
@@ -10,7 +9,7 @@ Change-Id: I252a8399c9853d993fc17d769bfbb2e4c722cfe8
  1 file changed, 4 insertions(+)
 
 diff --git a/init/util.cpp b/init/util.cpp
-index 82dfa05f0..4948772d0 100644
+index 82dfa05f02c004e11852ddcfc7d1d8ab17745c67..4948772d0c4947f12ed7dc8060b8e159176cc6a2 100644
 --- a/init/util.cpp
 +++ b/init/util.cpp
 @@ -83,12 +83,14 @@ Result<uid_t> DecodeUid(const std::string& name) {
@@ -38,6 +37,3 @@ index 82dfa05f0..4948772d0 100644
  
      struct sockaddr_un addr;
      memset(&addr, 0 , sizeof(addr));
--- 
-2.23.0
-

--- a/system/core/0029-hybris-disable-the-usage-of-libprocessgroup-since-it.patch
+++ b/system/core/0029-hybris-disable-the-usage-of-libprocessgroup-since-it.patch
@@ -1,8 +1,8 @@
-From 84c3120a703b845f6013a710bf892bab4307b621 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Wed, 6 Jun 2018 09:33:03 +0200
-Subject: [PATCH 29/50] (hybris) disable the usage of libprocessgroup, since it
- is incompatible.
+Subject: [PATCH] (hybris) disable the usage of libprocessgroup, since it is
+ incompatible.
 
 Change-Id: Ie37ac0dcc5cabbf33de55c148009fdfff3e90c64
 ---
@@ -12,7 +12,7 @@ Change-Id: Ie37ac0dcc5cabbf33de55c148009fdfff3e90c64
  3 files changed, 16 insertions(+), 8 deletions(-)
 
 diff --git a/init/Android.bp b/init/Android.bp
-index 6be7290e3..0be06b5ad 100644
+index 6be7290e3278eb1ab3daa80d015c8ecbdd5b8a50..0be06b5ad5266ff76b0423f38f75781c5d699907 100644
 --- a/init/Android.bp
 +++ b/init/Android.bp
 @@ -84,8 +84,6 @@ cc_defaults {
@@ -33,7 +33,7 @@ index 6be7290e3..0be06b5ad 100644
          "libcutils",
      ],
 diff --git a/init/init.cpp b/init/init.cpp
-index 28a2d6661..8ff468ea9 100644
+index 28a2d6661b97e7ee0cea0030b2d53b9c351024b2..8ff468ea9a1eeb859dce5302326dd4964425c1ce 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
 @@ -43,8 +43,6 @@
@@ -46,7 +46,7 @@ index 28a2d6661..8ff468ea9 100644
  
  #ifndef RECOVERY
 diff --git a/init/service.cpp b/init/service.cpp
-index 21b22aefb..b39282d53 100644
+index 21b22aefb33103b2b05043999795a17d8f163156..b39282d533cbc9be06ac981c16b9303d99c22c29 100644
 --- a/init/service.cpp
 +++ b/init/service.cpp
 @@ -38,7 +38,6 @@
@@ -119,6 +119,3 @@ index 21b22aefb..b39282d53 100644
      NotifyStateChange("running");
      return Success();
  }
--- 
-2.23.0
-

--- a/system/core/0030-hybris-disable-vendor-symlink.patch
+++ b/system/core/0030-hybris-disable-vendor-symlink.patch
@@ -1,7 +1,7 @@
-From 9a27750a2b278c27445425edf52bb1590b5146c9 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Thu, 7 Jun 2018 15:29:53 +0000
-Subject: [PATCH 30/50] (hybris) disable vendor symlink
+Subject: [PATCH] (hybris) disable vendor symlink
 
 Change-Id: I26a32268e2f3af7ab0550397900f7a3ef0edfae5
 ---
@@ -9,7 +9,7 @@ Change-Id: I26a32268e2f3af7ab0550397900f7a3ef0edfae5
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 543970e46..29d8af76a 100644
+index 543970e46745e5eacfb0313f3e985aad4239c51a..29d8af76ac96284b3629e0a4e1000a1585b92e57 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -56,7 +56,9 @@ on init
@@ -23,6 +23,3 @@ index 543970e46..29d8af76a 100644
  
      # Create energy-aware scheduler tuning nodes
      mkdir /dev/stune/foreground
--- 
-2.23.0
-

--- a/system/core/0031-hybris-ignore-mount-and-mkdir-tmp-commands-entirely.patch
+++ b/system/core/0031-hybris-ignore-mount-and-mkdir-tmp-commands-entirely.patch
@@ -1,8 +1,7 @@
-From 108b8eee47e032f4d1049a2d0eea1ad512475df4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 27 Aug 2018 11:08:12 +0000
-Subject: [PATCH 31/50] (hybris) ignore "mount" and "mkdir /tmp" commands
- entirely.
+Subject: [PATCH] (hybris) ignore "mount" and "mkdir /tmp" commands entirely.
 
 mount is usually removed during build, but if the *.rc files are on
 partitions we cannot easily change this is required (e.g. system,
@@ -21,7 +20,7 @@ Change-Id: Iba637613c6a927098c947536e11348e269e1bef3
  1 file changed, 16 insertions(+)
 
 diff --git a/init/builtins.cpp b/init/builtins.cpp
-index f98f37ed5..e4d5e48f8 100644
+index f98f37ed535a18dafb1611ad9f7682c31864ea55..e4d5e48f80a62c3229589bfb23a06f8a2cf66ca1 100644
 --- a/init/builtins.cpp
 +++ b/init/builtins.cpp
 @@ -301,6 +301,13 @@ static Result<Success> do_interface_stop(const BuiltinArguments& args) {
@@ -72,6 +71,3 @@ index f98f37ed5..e4d5e48f8 100644
  }
  
  /* Imports .rc files from the specified paths. Default ones are applied if none is given.
--- 
-2.23.0
-

--- a/system/core/0032-hybris-Fix-actdead-charging-animation.-MER-1949.patch
+++ b/system/core/0032-hybris-Fix-actdead-charging-animation.-MER-1949.patch
@@ -1,14 +1,14 @@
-From 1ac6ca6abb8c016bf9c85287d546bbe0b32a61a9 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Thu, 30 Aug 2018 19:54:16 +0300
-Subject: [PATCH 32/50] (hybris) Fix actdead charging animation. MER#1949
+Subject: [PATCH] (hybris) Fix actdead charging animation. MER#1949
 
 ---
  rootdir/init.rc | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 29d8af76a..70a15977e 100644
+index 29d8af76ac96284b3629e0a4e1000a1585b92e57..70a15977ec2d5b54a9e3be881045eaf34cc04c63 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -782,7 +782,7 @@ on property:droid.late_start=trigger_late_start
@@ -20,6 +20,3 @@ index 29d8af76a..70a15977e 100644
  
  on property:vold.decrypt=trigger_load_persist_props
      load_persist_props
--- 
-2.23.0
-

--- a/system/core/0033-hybris-system-core-Disable-usb-config.patch
+++ b/system/core/0033-hybris-system-core-Disable-usb-config.patch
@@ -1,7 +1,7 @@
-From 89179ec5b69057cfb17223c18179dbd8063be9a4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Matti Kosola <matti.kosola@jolla.com>
 Date: Tue, 21 Feb 2017 13:13:26 +0100
-Subject: [PATCH 33/50] (hybris)[system/core] Disable usb config.
+Subject: [PATCH] (hybris)[system/core] Disable usb config.
 
 Signed-off-by: Matti Kosola <matti.kosola@jolla.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Matti Kosola <matti.kosola@jolla.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 70a15977e..5d5468262 100644
+index 70a15977ec2d5b54a9e3be881045eaf34cc04c63..5d5468262983979605825f6457206336a246f444 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -15,7 +15,7 @@ import /init.environ.rc
@@ -21,6 +21,3 @@ index 70a15977e..5d5468262 100644
  import /init.${ro.zygote}.rc
  
  # Cgroups are mounted right before early-init using list from /etc/cgroups.json
--- 
-2.23.0
-

--- a/system/core/0034-hybris-Remove-sbin-from-droid-PATH.patch
+++ b/system/core/0034-hybris-Remove-sbin-from-droid-PATH.patch
@@ -1,14 +1,14 @@
-From 2041529d9c5666862e174151dfa9df9d4ae9e7ce Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jussi Laakkonen <jussi.laakkonen@jolla.com>
 Date: Wed, 31 Jan 2018 17:12:14 +0200
-Subject: [PATCH 34/50] (hybris) Remove /sbin from droid PATH.
+Subject: [PATCH] (hybris) Remove /sbin from droid PATH.
 
 ---
  rootdir/init.environ.rc.in | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/rootdir/init.environ.rc.in b/rootdir/init.environ.rc.in
-index 73fbaa413..8f95df9c6 100644
+index 73fbaa4133cecf6bf8ab85bfbc67638433c5c910..8f95df9c62a9dd5585c6648b83937373a7082e5e 100644
 --- a/rootdir/init.environ.rc.in
 +++ b/rootdir/init.environ.rc.in
 @@ -1,6 +1,6 @@
@@ -19,6 +19,3 @@ index 73fbaa413..8f95df9c6 100644
      # this breaks mixed 32/64-bit devices -mal
      # for 32-bit devices with android kernel logger there is now a file called init.extraenv.armeabi-v7a.rc - krnlyng
      # export LD_LIBRARY_PATH /usr/libexec/droid-hybris/lib64-dev-alog:/vendor/lib64:/system/lib64:/usr/libexec/droid-hybris/lib-dev-alog:/vendor/lib:/system/lib
--- 
-2.23.0
-

--- a/system/core/0035-hybris-Fix-return-value-type-of-mount-command.patch
+++ b/system/core/0035-hybris-Fix-return-value-type-of-mount-command.patch
@@ -1,7 +1,7 @@
-From a651ef33d8b26ae38196bd5ba64cf3aa7415f8a8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@gmail.com>
 Date: Sun, 18 Nov 2018 18:51:22 +0200
-Subject: [PATCH 35/50] (hybris) Fix return value type of mount command.
+Subject: [PATCH] (hybris) Fix return value type of mount command.
 
 Change-Id: Ib759e1be92d110863e43f13f7317372c6182a02d
 ---
@@ -9,7 +9,7 @@ Change-Id: Ib759e1be92d110863e43f13f7317372c6182a02d
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/init/builtins.cpp b/init/builtins.cpp
-index e4d5e48f8..c5b5d6d0f 100644
+index e4d5e48f80a62c3229589bfb23a06f8a2cf66ca1..c5b5d6d0fa6cce24fe77456071c2220e484fabe4 100644
 --- a/init/builtins.cpp
 +++ b/init/builtins.cpp
 @@ -678,7 +678,7 @@ static Result<Success> do_mount_all(const BuiltinArguments& args) {
@@ -21,6 +21,3 @@ index e4d5e48f8..c5b5d6d0f 100644
      property_set(prop_name, std::to_string(t.duration().count()));
  
      if (import_rc) {
--- 
-2.23.0
-

--- a/system/core/0036-hybris-disable-some-more-selinux-functionality.patch
+++ b/system/core/0036-hybris-disable-some-more-selinux-functionality.patch
@@ -1,7 +1,7 @@
-From 233d54ef951c478b2076821f216d479456e5d454 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <f_haider@gmx.at>
 Date: Thu, 28 Mar 2019 12:46:12 -0400
-Subject: [PATCH 36/50] (hybris) disable some more selinux functionality.
+Subject: [PATCH] (hybris) disable some more selinux functionality.
 
 Change-Id: Ie63eb13b73d626668b32041fec4400cf2edd2fe5
 ---
@@ -11,7 +11,7 @@ Change-Id: Ie63eb13b73d626668b32041fec4400cf2edd2fe5
  3 files changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/init/property_service.cpp b/init/property_service.cpp
-index b60d8d143..620507789 100644
+index b60d8d143d1cf47152d9d5690a25c73d3d37f7bb..6205077895cc09c756ef7ec108724b9d0b432e2a 100644
 --- a/init/property_service.cpp
 +++ b/init/property_service.cpp
 @@ -353,11 +353,14 @@ class SocketConnection {
@@ -30,7 +30,7 @@ index b60d8d143..620507789 100644
  
    private:
 diff --git a/init/subcontext.cpp b/init/subcontext.cpp
-index 092c51ceb..f0ea236d2 100644
+index 092c51ceb376349fba76d6bd62382f833ff81a1f..f0ea236d2aa9766b4a3ca5ff3fed01fd5848024c 100644
 --- a/init/subcontext.cpp
 +++ b/init/subcontext.cpp
 @@ -249,11 +249,11 @@ void Subcontext::Fork() {
@@ -48,7 +48,7 @@ index 092c51ceb..f0ea236d2 100644
          auto child_fd_string = std::to_string(child_fd);
          const char* args[] = {init_path.c_str(), "subcontext", context_.c_str(),
 diff --git a/init/util.cpp b/init/util.cpp
-index 4948772d0..c225d0643 100644
+index 4948772d0c4947f12ed7dc8060b8e159176cc6a2..c225d064387510bf92ea0b6bf7f6b7b51b0d62b5 100644
 --- a/init/util.cpp
 +++ b/init/util.cpp
 @@ -113,10 +113,12 @@ int CreateSocket(const char* name, int type, bool passcred, mode_t perm, uid_t u
@@ -76,6 +76,3 @@ index 4948772d0..c225d0643 100644
  
      if (ret) {
          errno = savederrno;
--- 
-2.23.0
-

--- a/system/core/0037-hybris-Disable-mnt-tmpfs-creation.patch
+++ b/system/core/0037-hybris-Disable-mnt-tmpfs-creation.patch
@@ -1,7 +1,7 @@
-From ae0512307ee34ecff25f6dc25f3dc5c5c65c6c3a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 3 Jun 2019 13:46:44 +0200
-Subject: [PATCH 37/50] (hybris) Disable /mnt tmpfs creation
+Subject: [PATCH] (hybris) Disable /mnt tmpfs creation
 
 Change-Id: I7c4fb119475adc345104f6ac5a68b578b6b2d433
 ---
@@ -9,7 +9,7 @@ Change-Id: I7c4fb119475adc345104f6ac5a68b578b6b2d433
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/init/first_stage_init.cpp b/init/first_stage_init.cpp
-index 998374a84..0e398b453 100644
+index 998374a8401eee4b8c22dd71dd4d5425b2d781de..0e398b4537269e191fdbc881d156497df084c62a 100644
 --- a/init/first_stage_init.cpp
 +++ b/init/first_stage_init.cpp
 @@ -149,8 +149,8 @@ int FirstStageMain(int argc, char** argv) {
@@ -23,6 +23,3 @@ index 998374a84..0e398b453 100644
      // /mnt/vendor is used to mount vendor-specific partitions that can not be
      // part of the vendor partition, e.g. because they are mounted read-write.
      CHECKCALL(mkdir("/mnt/vendor", 0755));
--- 
-2.23.0
-

--- a/system/core/0038-hybris-Disable-init_user0-which-is-not-needed-on-Mer.patch
+++ b/system/core/0038-hybris-Disable-init_user0-which-is-not-needed-on-Mer.patch
@@ -1,14 +1,14 @@
-From 1e5788e7141ee30063d8652e0079e8ce0370b8b1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matti=20Lehtim=C3=A4ki?= <matti.lehtimaki@jolla.com>
 Date: Mon, 10 Dec 2018 12:11:06 +0200
-Subject: [PATCH 38/50] (hybris) Disable init_user0 which is not needed on Mer.
+Subject: [PATCH] (hybris) Disable init_user0 which is not needed on Mer.
 
 ---
  rootdir/init.rc | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index 5d5468262..c5e71291d 100644
+index 5d5468262983979605825f6457206336a246f444..c5e71291d517780873311e39cbbebcb450a8f624 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -605,7 +605,7 @@ on post-fs-data
@@ -20,6 +20,3 @@ index 5d5468262..c5e71291d 100644
  
      # Set SELinux security contexts on upgrade or policy update.
      restorecon --recursive --skip-ce /data
--- 
-2.23.0
-

--- a/system/core/0039-hybris-Disable-SELinux-init.patch
+++ b/system/core/0039-hybris-Disable-SELinux-init.patch
@@ -1,7 +1,7 @@
-From 57cc123a345acb3d062a02630bcfcb9920cb1811 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Matti Kosola <matti.kosola@jolla.com>
 Date: Wed, 4 Sep 2019 12:07:34 +0200
-Subject: [PATCH 39/50] (hybris) Disable SELinux init.
+Subject: [PATCH] (hybris) Disable SELinux init.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -20,7 +20,7 @@ Signed-off-by: Björn Bidar <theodorstormgrade@gmail.com>
  3 files changed, 26 insertions(+)
 
 diff --git a/init/first_stage_init.cpp b/init/first_stage_init.cpp
-index 0e398b453..805bad2e5 100644
+index 0e398b4537269e191fdbc881d156497df084c62a..805bad2e5904886298d18e0a58af834421ab1dfc 100644
 --- a/init/first_stage_init.cpp
 +++ b/init/first_stage_init.cpp
 @@ -47,6 +47,8 @@ using namespace std::literals;
@@ -43,7 +43,7 @@ index 0e398b453..805bad2e5 100644
      CHECKCALL(mknod("/dev/kmsg", S_IFCHR | 0600, makedev(1, 11)));
  
 diff --git a/init/init.cpp b/init/init.cpp
-index 8ff468ea9..f2936d883 100644
+index 8ff468ea9a1eeb859dce5302326dd4964425c1ce..f2936d8831bb70f96b66cca02761430b529ab1ef 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
 @@ -76,6 +76,8 @@ using android::base::Timer;
@@ -84,7 +84,7 @@ index 8ff468ea9..f2936d883 100644
      Epoll epoll;
      if (auto result = epoll.Open(); !result) {
 diff --git a/init/selinux.cpp b/init/selinux.cpp
-index 2fc027ba2..ce506dd5e 100644
+index 2fc027ba201eeb1eac8d6e589194eec5a6be5beb..ce506dd5e0be7af3960e0760ca57104b777ae760 100644
 --- a/init/selinux.cpp
 +++ b/init/selinux.cpp
 @@ -74,6 +74,8 @@ using android::base::Timer;
@@ -171,6 +171,3 @@ index 2fc027ba2..ce506dd5e 100644
      return 1;
  }
  
--- 
-2.23.0
-

--- a/system/core/0040-hybris-Disable-unused-code-that-was-disabled-by-prev.patch
+++ b/system/core/0040-hybris-Disable-unused-code-that-was-disabled-by-prev.patch
@@ -1,8 +1,8 @@
-From 51435676f9d86e092dcef1c36aa998b726db2f7e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Bj=C3=B6rn=20Bidar?= <theodorstormgrade@gmail.com>
 Date: Sun, 20 Oct 2019 15:19:55 +0200
-Subject: [PATCH 40/50] (hybris) Disable unused code that was disabled by
- previous patches.
+Subject: [PATCH] (hybris) Disable unused code that was disabled by previous
+ patches.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -14,7 +14,7 @@ Signed-off-by: Björn Bidar <theodorstormgrade@gmail.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/init/service.cpp b/init/service.cpp
-index b39282d53..e77423eea 100644
+index b39282d533cbc9be06ac981c16b9303d99c22c29..e77423eea5a3b749179929c396c7a30fe99f648c 100644
 --- a/init/service.cpp
 +++ b/init/service.cpp
 @@ -190,6 +190,7 @@ Result<Success> Service::EnterNamespaces() const {
@@ -38,6 +38,3 @@ index b39282d53..e77423eea 100644
  
  unsigned long Service::next_start_order_ = 1;
  bool Service::is_exec_service_running_ = false;
--- 
-2.23.0
-

--- a/system/core/0041-hybris-Don-t-create-mount-proc-apex-dev-null-random.patch
+++ b/system/core/0041-hybris-Don-t-create-mount-proc-apex-dev-null-random.patch
@@ -1,8 +1,7 @@
-From 740af4a340658bc08ef96ff2648069073c8e1f19 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 12 Oct 2020 14:22:46 +0000
-Subject: [PATCH 41/50] (hybris) Don't create/mount proc, apex, dev/null,
- random, ...
+Subject: [PATCH] (hybris) Don't create/mount proc, apex, dev/null, random, ...
 
 Signed-off-by: Simonas Leleiva <simonas.leleiva@jolla.com>
 Change-Id: I3040e7e1ddf6d30644d8dc249ed3f0a6d6633615
@@ -11,7 +10,7 @@ Change-Id: I3040e7e1ddf6d30644d8dc249ed3f0a6d6633615
  1 file changed, 12 insertions(+), 12 deletions(-)
 
 diff --git a/init/first_stage_init.cpp b/init/first_stage_init.cpp
-index 805bad2e5..a60e91f83 100644
+index 805bad2e5904886298d18e0a58af834421ab1dfc..a60e91f83a7db8df0166906a9de3287a83e8e3af 100644
 --- a/init/first_stage_init.cpp
 +++ b/init/first_stage_init.cpp
 @@ -124,7 +124,7 @@ int FirstStageMain(int argc, char** argv) {
@@ -72,6 +71,3 @@ index 805bad2e5..a60e91f83 100644
  #undef CHECKCALL
  
      SetStdioToDevNull(argv);
--- 
-2.23.0
-

--- a/system/core/0042-hybris-change-system-bin-init-to-sbin-droid-hal-init.patch
+++ b/system/core/0042-hybris-change-system-bin-init-to-sbin-droid-hal-init.patch
@@ -1,8 +1,7 @@
-From f359d5a20677f4ce51f79c3fef3475d5832c5ee4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 12 Oct 2020 15:26:00 +0000
-Subject: [PATCH 42/50] (hybris) change /system/bin/init to
- /sbin/droid-hal-init
+Subject: [PATCH] (hybris) change /system/bin/init to /sbin/droid-hal-init
 
 Signed-off-by: Simonas Leleiva <simonas.leleiva@jolla.com>
 Change-Id: I29e02a59bb6be56a2aa0bd89e8a0602b9d0b14d6
@@ -12,7 +11,7 @@ Change-Id: I29e02a59bb6be56a2aa0bd89e8a0602b9d0b14d6
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/init/first_stage_init.cpp b/init/first_stage_init.cpp
-index a60e91f83..964cbb873 100644
+index a60e91f83a7db8df0166906a9de3287a83e8e3af..964cbb873aee4fa91bbc21684f810e0522088507 100644
 --- a/init/first_stage_init.cpp
 +++ b/init/first_stage_init.cpp
 @@ -239,7 +239,7 @@ int FirstStageMain(int argc, char** argv) {
@@ -25,7 +24,7 @@ index a60e91f83..964cbb873 100644
      execv(path, const_cast<char**>(args));
  
 diff --git a/init/selinux.cpp b/init/selinux.cpp
-index ce506dd5e..13310740a 100644
+index ce506dd5e0be7af3960e0760ca57104b777ae760..13310740a00aca1aadf9ad7fcf7ae54d3fde9513 100644
 --- a/init/selinux.cpp
 +++ b/init/selinux.cpp
 @@ -552,7 +552,7 @@ int SetupSelinux(char** argv) {
@@ -37,6 +36,3 @@ index ce506dd5e..13310740a 100644
      const char* args[] = {path, "second_stage", nullptr};
      execv(path, const_cast<char**>(args));
  
--- 
-2.23.0
-

--- a/system/core/0043-hybris-allow-second-stage-init-previously-disabled-b.patch
+++ b/system/core/0043-hybris-allow-second-stage-init-previously-disabled-b.patch
@@ -1,7 +1,7 @@
-From 59e5143bbb53b4663c9cf335253fcb4ea6f8cc65 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 12 Oct 2020 15:29:00 +0000
-Subject: [PATCH 43/50] (hybris) allow second stage init previously disabled by
+Subject: [PATCH] (hybris) allow second stage init previously disabled by
  selinux work
 
 Signed-off-by: Simonas Leleiva <simonas.leleiva@jolla.com>
@@ -11,7 +11,7 @@ Change-Id: I1089428e88e7d94457f76745b23f44728dba8f6e
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/init/selinux.cpp b/init/selinux.cpp
-index 13310740a..853ee03e5 100644
+index 13310740a00aca1aadf9ad7fcf7ae54d3fde9513..853ee03e50a70adce1fdc19b41870774d9a882b3 100644
 --- a/init/selinux.cpp
 +++ b/init/selinux.cpp
 @@ -551,6 +551,7 @@ int SetupSelinux(char** argv) {
@@ -30,6 +30,3 @@ index 13310740a..853ee03e5 100644
      return 1;
  }
  
--- 
-2.23.0
-

--- a/system/core/0044-hybris-Don-t-bail-out-if-failed-to-initialize-proper.patch
+++ b/system/core/0044-hybris-Don-t-bail-out-if-failed-to-initialize-proper.patch
@@ -1,8 +1,7 @@
-From 4933417b73d39fb52abed8eed7a5365a4d00d5b6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 12 Oct 2020 16:48:00 +0000
-Subject: [PATCH 44/50] (hybris) Don't bail out if failed to initialize
- property area
+Subject: [PATCH] (hybris) Don't bail out if failed to initialize property area
 
 Signed-off-by: Simonas Leleiva <simonas.leleiva@jolla.com>
 Change-Id: Ie9fe31f9e60510b91fcd857b0715b6fcc253dfee
@@ -11,7 +10,7 @@ Change-Id: Ie9fe31f9e60510b91fcd857b0715b6fcc253dfee
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/init/property_service.cpp b/init/property_service.cpp
-index 620507789..8275f9cb8 100644
+index 6205077895cc09c756ef7ec108724b9d0b432e2a..8275f9cb85a6192edfdb5284ea62060df5b90be4 100644
 --- a/init/property_service.cpp
 +++ b/init/property_service.cpp
 @@ -104,7 +104,7 @@ void property_init() {
@@ -23,6 +22,3 @@ index 620507789..8275f9cb8 100644
      }
      if (!property_info_area.LoadDefaultPath()) {
          LOG(FATAL) << "Failed to load serialized property info file";
--- 
-2.23.0
-

--- a/system/core/0045-hybris-create-dev-socket-during-first-stage.patch
+++ b/system/core/0045-hybris-create-dev-socket-during-first-stage.patch
@@ -1,7 +1,7 @@
-From 71ef9dc6953122f5a567def945134de3b1a64cf5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 12 Oct 2020 17:11:00 +0000
-Subject: [PATCH 45/50] (hybris) create /dev/socket during first stage
+Subject: [PATCH] (hybris) create /dev/socket during first stage
 
 It will attempt to create it again during 2nd stage, do not fail then.
 
@@ -12,7 +12,7 @@ Change-Id: I4701723d55032e35228a84bff81b20cc93424c32
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/init/first_stage_init.cpp b/init/first_stage_init.cpp
-index 964cbb873..0550b379c 100644
+index 964cbb873aee4fa91bbc21684f810e0522088507..0550b379c519de96548ec926e17e7b84cb05fae7 100644
 --- a/init/first_stage_init.cpp
 +++ b/init/first_stage_init.cpp
 @@ -121,7 +121,7 @@ int FirstStageMain(int argc, char** argv) {
@@ -24,6 +24,3 @@ index 964cbb873..0550b379c 100644
      //CHECKCALL(mount("devpts", "/dev/pts", "devpts", 0, NULL));
  #define MAKE_STR(x) __STRING(x)
      //CHECKCALL(mount("proc", "/proc", "proc", 0, "hidepid=2,gid=" MAKE_STR(AID_READPROC)));
--- 
-2.23.0
-

--- a/system/core/0046-hybris-execve-service.patch
+++ b/system/core/0046-hybris-execve-service.patch
@@ -1,7 +1,7 @@
-From e9e08887b93efbea2c9af47e1b5394ba89fa030e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Mon, 12 Oct 2020 19:25:00 +0000
-Subject: [PATCH 46/50] (hybris) execve service
+Subject: [PATCH] (hybris) execve service
 
 Signed-off-by: Simonas Leleiva <simonas.leleiva@jolla.com>
 Change-Id: I2efa4048bc2e4da848a61e24d8ef8b1824a81f06
@@ -10,7 +10,7 @@ Change-Id: I2efa4048bc2e4da848a61e24d8ef8b1824a81f06
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/init/service.cpp b/init/service.cpp
-index e77423eea..894951a1e 100644
+index e77423eea5a3b749179929c396c7a30fe99f648c..894951a1e1bbe3ece8f9e5d22f759379254673b2 100644
 --- a/init/service.cpp
 +++ b/init/service.cpp
 @@ -190,7 +190,6 @@ Result<Success> Service::EnterNamespaces() const {
@@ -45,6 +45,3 @@ index e77423eea..894951a1e 100644
          _exit(127);
      }
  
--- 
-2.23.0
-

--- a/system/core/0047-hybris-Do-not-SetupMountNamespaces.patch
+++ b/system/core/0047-hybris-Do-not-SetupMountNamespaces.patch
@@ -1,7 +1,7 @@
-From 61cb16db3e9354f798e300568b40fdde18f92099 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Tue, 13 Oct 2020 13:29:00 +0000
-Subject: [PATCH 47/50] (hybris) Do not SetupMountNamespaces()
+Subject: [PATCH] (hybris) Do not SetupMountNamespaces()
 
 Signed-off-by: Simonas Leleiva <simonas.leleiva@jolla.com>
 Change-Id: Id2af1396ed2274a3533305722e117786aceb3cd0
@@ -10,7 +10,7 @@ Change-Id: Id2af1396ed2274a3533305722e117786aceb3cd0
  1 file changed, 2 insertions(+)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index f2936d883..20aa65f37 100644
+index f2936d8831bb70f96b66cca02761430b529ab1ef..20aa65f372e0184507e104c22d7a3b35ff297e18 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
 @@ -705,9 +705,11 @@ int SecondStageMain(int argc, char** argv) {
@@ -25,6 +25,3 @@ index f2936d883..20aa65f37 100644
  
      subcontexts = InitializeSubcontexts();
  
--- 
-2.23.0
-

--- a/system/core/0048-hybris-Do-not-launch-system-bin-vdc.patch
+++ b/system/core/0048-hybris-Do-not-launch-system-bin-vdc.patch
@@ -1,7 +1,7 @@
-From 149bf24830f3ac0d10067a49e437084bd2936c93 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Tue, 13 Oct 2020 15:39:00 +0000
-Subject: [PATCH 48/50] (hybris) Do not launch /system/bin/vdc
+Subject: [PATCH] (hybris) Do not launch /system/bin/vdc
 
 Signed-off-by: Simonas Leleiva <simonas.leleiva@jolla.com>
 Change-Id: Ic786cc3e8734c439309aeea09992a2b8859ad0ca
@@ -10,7 +10,7 @@ Change-Id: Ic786cc3e8734c439309aeea09992a2b8859ad0ca
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index c5e71291d..efa1884b4 100644
+index c5e71291d517780873311e39cbbebcb450a8f624..efa1884b46ce1f20b5bd39bf4d4f0c771e3ef976 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -353,7 +353,7 @@ on early-fs
@@ -31,6 +31,3 @@ index c5e71291d..efa1884b4 100644
  
      # We chown/chmod /data again so because mount is run as root + defaults
      chown system system /data
--- 
-2.23.0
-

--- a/system/core/0049-hybris-Allow-input-group-to-use-vibrator.patch
+++ b/system/core/0049-hybris-Allow-input-group-to-use-vibrator.patch
@@ -1,8 +1,8 @@
-From a13bc55e4b1ce6bc211b5475d59988a1ad100e56 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
  <juho.hamalainen@jolla.com>
 Date: Mon, 23 Mar 2020 17:40:04 +0200
-Subject: [PATCH 49/50] (hybris) Allow input group to use vibrator.
+Subject: [PATCH] (hybris) Allow input group to use vibrator.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -16,7 +16,7 @@ Change-Id: I2b86d9eec1b20301a128a4f9f83b5edb4b2da234
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index efa1884b4..a9b7e8112 100644
+index efa1884b46ce1f20b5bd39bf4d4f0c771e3ef976..a9b7e81124b258e202219cdc23babeb0cc405b7a 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -733,10 +733,11 @@ on boot
@@ -33,6 +33,3 @@ index efa1884b4..a9b7e8112 100644
      chown system system /sys/class/leds/vibrator/state
      chown system system /sys/class/timed_output/vibrator/enable
      chown system system /sys/class/leds/keyboard-backlight/brightness
--- 
-2.23.0
-

--- a/system/core/0050-hybris-Allow-input-group-to-use-old-vibrator.patch
+++ b/system/core/0050-hybris-Allow-input-group-to-use-old-vibrator.patch
@@ -1,8 +1,8 @@
-From 6444d034c7f405d5ff05c5989dab6b01c8ed635c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Juho=20H=C3=A4m=C3=A4l=C3=A4inen?=
  <juho.hamalainen@jolla.com>
 Date: Tue, 24 Mar 2020 14:07:40 +0200
-Subject: [PATCH 50/50] (hybris) Allow input group to use old vibrator.
+Subject: [PATCH] (hybris) Allow input group to use old vibrator.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -14,7 +14,7 @@ Change-Id: I279b97beb82a5de51d40535221a2b71d3468a91f
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/rootdir/init.rc b/rootdir/init.rc
-index a9b7e8112..f68597523 100644
+index a9b7e81124b258e202219cdc23babeb0cc405b7a..f68597523479cd28040fe8e0e63f3bb2d7c71cf5 100644
 --- a/rootdir/init.rc
 +++ b/rootdir/init.rc
 @@ -739,7 +739,8 @@ on boot
@@ -27,6 +27,3 @@ index a9b7e8112..f68597523 100644
      chown system system /sys/class/leds/keyboard-backlight/brightness
      chown system system /sys/class/leds/lcd-backlight/brightness
      chown system system /sys/class/leds/button-backlight/brightness
--- 
-2.23.0
-


### PR DESCRIPTION
[frameworks] native: pick egl/gles libraries from the correct path also in the 64 bit case. JB#53238

Also use the new way of exporting patches.

New patch is:  0004-hybris-Pick-GLES-shared-objects-from-appropriate-pat.patch 