### PR TITLE
frameworks: No longer patch servicemanager.rc to start minisf

### DIFF
--- a/frameworks/native/0001-hybris-Use-mini-services-and-disable-starting-unneed.patch
+++ b/frameworks/native/0001-hybris-Use-mini-services-and-disable-starting-unneed.patch
@@ -13,7 +13,7 @@ diff --git a/cmds/servicemanager/servicemanager.rc b/cmds/servicemanager/service
 index 4d93cb4..1930612 100644
 --- a/cmds/servicemanager/servicemanager.rc
 +++ b/cmds/servicemanager/servicemanager.rc
-@@ -4,14 +4,33 @@ service servicemanager /system/bin/servicemanager
+@@ -4,14 +4,17 @@ service servicemanager /system/bin/servicemanager
      group system readproc
      critical
      onrestart restart healthd
@@ -40,22 +40,6 @@ index 4d93cb4..1930612 100644
 +    onrestart restart minisf
      writepid /dev/cpuset/system-background/tasks
      shutdown critical
-+
-+service minimedia /usr/libexec/droid-hybris/system/bin/minimediaservice
-+    class main
-+    user media
-+    group audio camera
-+    ioprio rt 4
-+
-+service minisf /usr/libexec/droid-hybris/system/bin/minisfservice
-+    class main
-+    user system
-+    group graphics
-+
-+service miniaf /usr/libexec/droid-hybris/system/bin/miniafservice
-+    class main
-+    user system
-+    group audio
 -- 
 2.7.4
 


### PR DESCRIPTION
- frameworks: No longer patch servicemanager.rc to start minisf
- Also restart miniaudiopolicy