### PR TITLE
hybris-18.1: Add 32-bit vs 64-bit codec compatibility patches

### DIFF
--- a/build/make/0001-hybris-Reduce-vendorimage-build-size.patch
+++ b/build/make/0001-hybris-Reduce-vendorimage-build-size.patch
@@ -9,7 +9,7 @@ Change-Id: Id025a7d7c81cb19c2881ff6619084b638ce983fb
  1 file changed, 10 insertions(+), 3 deletions(-)
 
 diff --git a/core/Makefile b/core/Makefile
-index 5b0430fdb629626aef91639554063ecfe74cbb71..db06f967f4fca544106edb5bc02c9215c2968e15 100644
+index b4189463472b6a45ac4efaf3dcad6ee6bc46cb4c..f23c9a3cfb9e0639380ba575f3885b14199ecc3a 100644
 --- a/core/Makefile
 +++ b/core/Makefile
 @@ -40,6 +40,7 @@ $(if $(filter true,$(BUILD_BROKEN_VINTF_PRODUCT_COPY_FILES)),, \

--- a/frameworks/av/0001-hybris-AudioService-is-disabled-in-hybris-adaptation.patch
+++ b/frameworks/av/0001-hybris-AudioService-is-disabled-in-hybris-adaptation.patch
@@ -16,10 +16,10 @@ Signed-off-by: Björn Bidar <theodorstormgrade@gmail.com>
  1 file changed, 7 insertions(+)
 
 diff --git a/services/camera/libcameraservice/CameraService.cpp b/services/camera/libcameraservice/CameraService.cpp
-index fcccd262fee9dbfeba55abded66dfa7beacc9bd8..730c243667dab4100a1af2784fedbb47e7b96cea 100644
+index c08810f52aeb4eb5178cef0320726714efcf4438..2e8c7159ed624915afaf21a3d5abd1b30adeba34 100644
 --- a/services/camera/libcameraservice/CameraService.cpp
 +++ b/services/camera/libcameraservice/CameraService.cpp
-@@ -2693,9 +2693,15 @@ void CameraService::increaseSoundRef() {
+@@ -2701,9 +2701,15 @@ void CameraService::increaseSoundRef() {
      mSoundRef++;
  }
  
@@ -35,7 +35,7 @@ index fcccd262fee9dbfeba55abded66dfa7beacc9bd8..730c243667dab4100a1af2784fedbb47
      LOG1("CameraService::loadSoundLocked ref=%d", mSoundRef);
      if (SOUND_SHUTTER == kind && mSoundPlayer[SOUND_SHUTTER] == NULL) {
          mSoundPlayer[SOUND_SHUTTER] = newMediaPlayer("/product/media/audio/ui/camera_click.ogg");
-@@ -2714,6 +2720,7 @@ void CameraService::loadSoundLocked(sound_kind kind) {
+@@ -2722,6 +2728,7 @@ void CameraService::loadSoundLocked(sound_kind kind) {
              mSoundPlayer[SOUND_RECORDING_STOP] = newMediaPlayer("/system/media/audio/ui/VideoStop.ogg");
          }
      }

--- a/frameworks/av/0002-hybris-Fix-32-bit-vs-64-bit-size-mismatch-in-codecs.patch
+++ b/frameworks/av/0002-hybris-Fix-32-bit-vs-64-bit-size-mismatch-in-codecs.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matti Lehtimaki <matti.lehtimaki@jolla.com>
+Date: Thu, 5 Nov 2020 20:46:35 +0200
+Subject: [PATCH] (hybris) Fix 32-bit vs 64-bit size mismatch in codecs.
+
+Change-Id: I50e928113f90eea9d85f79f183c4b74113ab73bf
+---
+ media/libstagefright/ACodec.cpp | 27 +++++++++++++++++++++++++--
+ 1 file changed, 25 insertions(+), 2 deletions(-)
+
+diff --git a/media/libstagefright/ACodec.cpp b/media/libstagefright/ACodec.cpp
+index 4a3b32f3eebf7bdaa57642f92aada6c6b813585f..d3c4603d31468e1e036d6a184c25f7e8ca7ed79d 100644
+--- a/media/libstagefright/ACodec.cpp
++++ b/media/libstagefright/ACodec.cpp
+@@ -887,10 +887,11 @@ status_t ACodec::allocateBuffersOnPort(OMX_U32 portIndex) {
+             // Always allocate VideoNativeMetadata if using ANWBuffer.
+             // OMX might use gralloc source internally, but we don't share
+             // metadata buffer with OMX, OMX has its own headers.
++            // hybris: allocate buffer that can fit 64-bit native handle if compiled in 64-bit mode
+             if (mode == IOMX::kPortModeDynamicANWBuffer) {
+-                bufSize = sizeof(VideoNativeMetadata);
++                bufSize = sizeof(VideoNativeMetadata_ptrSized);
+             } else if (mode == IOMX::kPortModeDynamicNativeHandle) {
+-                bufSize = sizeof(VideoNativeHandleMetadata);
++                bufSize = sizeof(VideoNativeHandleMetadata_ptrSized);
+             }
+ 
+             size_t conversionBufferSize = 0;
+@@ -6298,6 +6299,28 @@ void ACodec::BaseState::onInputBufferFilled(const sp<AMessage> &msg) {
+                             bufferID, graphicBuffer, flags, timeUs, info->mFenceFd);
+                     }
+                     break;
++#else
++                // hybris: convert data from 64-bit camera process to 32-bit OMX if needed
++                case IOMX::kPortModeDynamicNativeHandle:
++                    if (info->mCodecData->size() >= sizeof(VideoNativeHandleMetadata_ptrSized)
++                            && sizeof(VideoNativeHandleMetadata) != sizeof(VideoNativeHandleMetadata_ptrSized)) {
++                        VideoNativeHandleMetadata_ptrSized *vnhmd =
++                            (VideoNativeHandleMetadata_ptrSized*)info->mCodecData->base();
++                        sp<NativeHandle> handle = NativeHandle::create(
++                                (native_handle *)vnhmd->pHandle, false /* ownsHandle */);
++                        err2 = mCodec->mOMXNode->emptyBuffer(
++                            bufferID, handle, flags, timeUs, info->mFenceFd);
++                    }
++                    break;
++                case IOMX::kPortModeDynamicANWBuffer:
++                    if (info->mCodecData->size() >= sizeof(VideoNativeMetadata_ptrSized)
++                            && sizeof(VideoNativeMetadata) != sizeof(VideoNativeMetadata_ptrSized)) {
++                        VideoNativeMetadata_ptrSized *vnmd = (VideoNativeMetadata_ptrSized*)info->mCodecData->base();
++                        sp<GraphicBuffer> graphicBuffer = GraphicBuffer::from(vnmd->pBuffer);
++                        err2 = mCodec->mOMXNode->emptyBuffer(
++                            bufferID, graphicBuffer, flags, timeUs, info->mFenceFd);
++                    }
++                    break;
+ #endif
+                 default:
+                     ALOGW("Can't marshall %s data in %zu sized buffers in %zu-bit mode",

--- a/frameworks/native/0002-hybris-Pick-GLES-shared-objects-from-appropriate-pat.patch
+++ b/frameworks/native/0002-hybris-Pick-GLES-shared-objects-from-appropriate-pat.patch
@@ -11,7 +11,7 @@ Signed-off-by: Simonas Leleiva <simonas.leleiva@jollamobile.com>
  1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/opengl/libs/EGL/Loader.cpp b/opengl/libs/EGL/Loader.cpp
-index d66ef2b96925fb61e47087cc0015cb1cbe4d7627..ac7c147210555ab56f7e86e173902ee50feb4d3d 100644
+index 0576a05948b39e4e114af08e8325a9d024350651..fbfd2a1d0657722e6c34dfea039817c67bb04984 100644
 --- a/opengl/libs/EGL/Loader.cpp
 +++ b/opengl/libs/EGL/Loader.cpp
 @@ -134,9 +134,9 @@ static void* load_wrapper(const char* path) {

--- a/frameworks/native/0004-hybris-Pick-GLES-shared-objects-from-appropriate-pat.patch
+++ b/frameworks/native/0004-hybris-Pick-GLES-shared-objects-from-appropriate-pat.patch
@@ -10,7 +10,7 @@ Change-Id: I71ac1072e68c4d97f2808592ac007f1dc470d69f
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/opengl/libs/EGL/Loader.cpp b/opengl/libs/EGL/Loader.cpp
-index ac7c147210555ab56f7e86e173902ee50feb4d3d..0f850185cff5390d7ef8db4a9c89215f706a57dd 100644
+index fbfd2a1d0657722e6c34dfea039817c67bb04984..5ccd60e956b69d3b70feaa63f8382721d373041c 100644
 --- a/opengl/libs/EGL/Loader.cpp
 +++ b/opengl/libs/EGL/Loader.cpp
 @@ -134,7 +134,7 @@ static void* load_wrapper(const char* path) {

--- a/frameworks/native/0005-hybris-do-not-expose-EGL_ANGLE_platform_angle-otherw.patch
+++ b/frameworks/native/0005-hybris-do-not-expose-EGL_ANGLE_platform_angle-otherw.patch
@@ -10,7 +10,7 @@ Change-Id: Ied98ee3f0943ac8a847b36239039aa305140a71b
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/opengl/libs/EGL/egl_platform_entries.cpp b/opengl/libs/EGL/egl_platform_entries.cpp
-index aa24e8ee68bb1bf9c2755ff4ff6585309dde9429..c2513d5f2e223b67e7984b8f583c17393aa177d2 100644
+index b68a7cd8a3e6bf2a2bdb77838af08497bf58c9eb..82e32a01e2133388682f93b295f458d90897883a 100644
 --- a/opengl/libs/EGL/egl_platform_entries.cpp
 +++ b/opengl/libs/EGL/egl_platform_entries.cpp
 @@ -137,7 +137,7 @@ char const * const gExtensionString  =

--- a/frameworks/native/0006-hybris-Add-native-buffer-compat-define.patch
+++ b/frameworks/native/0006-hybris-Add-native-buffer-compat-define.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matti Lehtimaki <matti.lehtimaki@jolla.com>
+Date: Thu, 5 Nov 2020 20:50:40 +0200
+Subject: [PATCH] (hybris) Add native buffer compat define.
+
+Change-Id: Iaa50a8270fc822fa3aacec07a5dcdfc467752afe
+---
+ headers/media_plugin/media/hardware/HardwareAPI.h | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/headers/media_plugin/media/hardware/HardwareAPI.h b/headers/media_plugin/media/hardware/HardwareAPI.h
+index ae0220a5ebfddde1286f59b1d5d6816313195499..05e9559a5a87bf801a61855df2d0122dbd94731a 100644
+--- a/headers/media_plugin/media/hardware/HardwareAPI.h
++++ b/headers/media_plugin/media/hardware/HardwareAPI.h
+@@ -150,6 +150,12 @@ struct VideoNativeMetadata {
+     int nFenceFd;                           // -1 if unused
+ };
+ 
++struct VideoNativeMetadata_ptrSized {
++    MetadataBufferType eType;               // must be kMetadataBufferTypeANWBuffer
++    struct ANativeWindowBuffer* pBuffer;
++    int nFenceFd;                           // -1 if unused
++};
++
+ // Meta data buffer layout for passing a native_handle to codec
+ struct VideoNativeHandleMetadata {
+     MetadataBufferType eType;               // must be kMetadataBufferTypeNativeHandleSource
+@@ -161,6 +167,14 @@ struct VideoNativeHandleMetadata {
+ #endif
+ };
+ 
++// Meta data buffer layout for passing a native_handle to codec
++// mer-hybris: 64-bit version used in conversion code for 32-bit OMX
++struct VideoNativeHandleMetadata_ptrSized {
++    MetadataBufferType eType;               // must be kMetadataBufferTypeNativeHandleSource
++
++    native_handle_t *pHandle;
++};
++
+ // A pointer to this struct is passed to OMX_SetParameter() when the extension
+ // index "OMX.google.android.index.prepareForAdaptivePlayback" is given.
+ //


### PR DESCRIPTION
Rebase patches on top of latest lineage-18.1.

Change-Id: I557af3ad07fc051567b2e8e3ba8764b2303713c0