### PR TITLE
hybris-17.1: Fix 32-bit vs 64-bit codec compatibility patches

### DIFF
--- a/art/0001-hybris-Silence-some-build-errors-to-let-the-systemim.patch
+++ b/art/0001-hybris-Silence-some-build-errors-to-let-the-systemim.patch
@@ -21,10 +21,10 @@ Change-Id: Ide41188b6263a22c371ec28786bbc1ef1ee62df7
  4 files changed, 17 insertions(+), 11 deletions(-)
 
 diff --git a/build/Android.gtest.mk b/build/Android.gtest.mk
-index 03aae07587d9f21ffcb1a0e3707ef32d003a80ee..20e38df7b2d18282fe63acea79097d7bb9e975f4 100644
+index 2249b1b75024864cd597216592f7d631cffa84ea..4b5ec87ca0476df546780486a0294f361001f286 100644
 --- a/build/Android.gtest.mk
 +++ b/build/Android.gtest.mk
-@@ -73,28 +73,28 @@ $(foreach dir,$(GTEST_DEX_DIRECTORIES), $(eval $(call build-art-test-dex,art-gte
+@@ -74,28 +74,28 @@ $(foreach dir,$(GTEST_DEX_DIRECTORIES), $(eval $(call build-art-test-dex,art-gte
  
  # Create rules for MainStripped, a copy of Main with the classes.dex stripped
  # for the oat file assistant tests.

--- a/frameworks/av/0002-hybris-Fix-32-bit-vs-64-bit-size-mismatch-in-codecs.patch
+++ b/frameworks/av/0002-hybris-Fix-32-bit-vs-64-bit-size-mismatch-in-codecs.patch
@@ -5,25 +5,28 @@ Subject: [PATCH] (hybris) Fix 32-bit vs 64-bit size mismatch in codecs.
 
 Change-Id: I50e928113f90eea9d85f79f183c4b74113ab73bf
 ---
- media/libstagefright/ACodec.cpp | 17 ++++++++++++++++-
- 1 file changed, 16 insertions(+), 1 deletion(-)
+ media/libstagefright/ACodec.cpp | 27 +++++++++++++++++++++++++--
+ 1 file changed, 25 insertions(+), 2 deletions(-)
 
 diff --git a/media/libstagefright/ACodec.cpp b/media/libstagefright/ACodec.cpp
-index 55e8130e48e8f00bf25a5935f5d4074df98f32e5..84408c40b522455fadfe50f8ced93aa5ea229bac 100644
+index 55e8130e48e8f00bf25a5935f5d4074df98f32e5..54590e047e9842de6f802808a052379eb41a1bf0 100644
 --- a/media/libstagefright/ACodec.cpp
 +++ b/media/libstagefright/ACodec.cpp
-@@ -880,7 +880,9 @@ status_t ACodec::allocateBuffersOnPort(OMX_U32 portIndex) {
+@@ -877,10 +877,11 @@ status_t ACodec::allocateBuffersOnPort(OMX_U32 portIndex) {
+             // Always allocate VideoNativeMetadata if using ANWBuffer.
+             // OMX might use gralloc source internally, but we don't share
+             // metadata buffer with OMX, OMX has its own headers.
++            // hybris: allocate buffer that can fit 64-bit native handle if compiled in 64-bit mode
              if (mode == IOMX::kPortModeDynamicANWBuffer) {
-                 bufSize = sizeof(VideoNativeMetadata);
+-                bufSize = sizeof(VideoNativeMetadata);
++                bufSize = sizeof(VideoNativeMetadata_ptrSized);
              } else if (mode == IOMX::kPortModeDynamicNativeHandle) {
 -                bufSize = sizeof(VideoNativeHandleMetadata);
-+                // hybris: allocate buffer that can fit 64-bit native handle if compiled in 64-bit mode
-+                //bufSize = sizeof(VideoNativeHandleMetadata);
 +                bufSize = sizeof(VideoNativeHandleMetadata_ptrSized);
              }
  
              size_t conversionBufferSize = 0;
-@@ -6147,6 +6149,19 @@ void ACodec::BaseState::onInputBufferFilled(const sp<AMessage> &msg) {
+@@ -6147,6 +6148,28 @@ void ACodec::BaseState::onInputBufferFilled(const sp<AMessage> &msg) {
                              bufferID, graphicBuffer, flags, timeUs, info->mFenceFd);
                      }
                      break;
@@ -38,6 +41,15 @@ index 55e8130e48e8f00bf25a5935f5d4074df98f32e5..84408c40b522455fadfe50f8ced93aa5
 +                                (native_handle *)vnhmd->pHandle, false /* ownsHandle */);
 +                        err2 = mCodec->mOMXNode->emptyBuffer(
 +                            bufferID, handle, flags, timeUs, info->mFenceFd);
++                    }
++                    break;
++                case IOMX::kPortModeDynamicANWBuffer:
++                    if (info->mCodecData->size() >= sizeof(VideoNativeMetadata_ptrSized)
++                            && sizeof(VideoNativeMetadata) != sizeof(VideoNativeMetadata_ptrSized)) {
++                        VideoNativeMetadata_ptrSized *vnmd = (VideoNativeMetadata_ptrSized*)info->mCodecData->base();
++                        sp<GraphicBuffer> graphicBuffer = GraphicBuffer::from(vnmd->pBuffer);
++                        err2 = mCodec->mOMXNode->emptyBuffer(
++                            bufferID, graphicBuffer, flags, timeUs, info->mFenceFd);
 +                    }
 +                    break;
  #endif

--- a/frameworks/native/0004-hybris-Add-native-buffer-compat-define.patch
+++ b/frameworks/native/0004-hybris-Add-native-buffer-compat-define.patch
@@ -5,14 +5,29 @@ Subject: [PATCH] (hybris) Add native buffer compat define.
 
 Change-Id: Iaa50a8270fc822fa3aacec07a5dcdfc467752afe
 ---
- headers/media_plugin/media/hardware/HardwareAPI.h | 8 ++++++++
- 1 file changed, 8 insertions(+)
+ .../media_plugin/media/hardware/HardwareAPI.h    | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
 
 diff --git a/headers/media_plugin/media/hardware/HardwareAPI.h b/headers/media_plugin/media/hardware/HardwareAPI.h
-index ae0220a5ebfddde1286f59b1d5d6816313195499..5c334138e8c47a309205ef7a56852dd037167001 100644
+index ae0220a5ebfddde1286f59b1d5d6816313195499..9f59a4b5349239aa919d010ada7e7972bea40163 100644
 --- a/headers/media_plugin/media/hardware/HardwareAPI.h
 +++ b/headers/media_plugin/media/hardware/HardwareAPI.h
-@@ -161,6 +161,14 @@ struct VideoNativeHandleMetadata {
+@@ -150,6 +150,14 @@ struct VideoNativeMetadata {
+     int nFenceFd;                           // -1 if unused
+ };
+ 
++// Meta data buffer layout for passing a native_handle to codec
++// mer-hybris: 64-bit version used in conversion code for 32-bit OMX
++struct VideoNativeMetadata_ptrSized {
++    MetadataBufferType eType;               // must be kMetadataBufferTypeANWBuffer
++    struct ANativeWindowBuffer* pBuffer;
++    int nFenceFd;                           // -1 if unused
++};
++
+ // Meta data buffer layout for passing a native_handle to codec
+ struct VideoNativeHandleMetadata {
+     MetadataBufferType eType;               // must be kMetadataBufferTypeNativeHandleSource
+@@ -161,6 +169,14 @@ struct VideoNativeHandleMetadata {
  #endif
  };
  

--- a/hardware/libhardware/0002-hybris-Search-for-libraries-first-from-usr-libexec-d.patch
+++ b/hardware/libhardware/0002-hybris-Search-for-libraries-first-from-usr-libexec-d.patch
@@ -10,7 +10,7 @@ Change-Id: I7496d961f8218b6077b9d628dd350ac20550b5d2
  1 file changed, 7 insertions(+)
 
 diff --git a/hardware.c b/hardware.c
-index 6e72ce9f344544a1d3f05792abd499711f8681d6..ecdcf87970d3c5cfaaa717deec4d83b03caa0746 100644
+index 6e72ce9f344544a1d3f05792abd499711f8681d6..cea20004328b885052b1571c0cabe3aad191ed60 100644
 --- a/hardware.c
 +++ b/hardware.c
 @@ -39,10 +39,12 @@


### PR DESCRIPTION
Re-export patches.

Change-Id: I93ad2f65d24e8d9faac5a2633069e217df6a0cf3